### PR TITLE
Added blocktad feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "blocktad-merging"
+version = "0.1.0"
+dependencies = [
+ "germterm",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "examples/hello-world",
     "examples/standard-blending",
     "examples/octad-merging",
+    "examples/blocktad-merging",
     "examples/octad-particles",
     "examples/twoxel-tester",
     "examples/twoxel-snake",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ It renders in real time, adds support for the alpha channel, adds multiple drawi
 ## Getting started
 
 Add `germterm` as a dependency:
-```
+```plain_text,no_run
 cargo add germterm
 ```
 

--- a/examples/blocktad-merging/Cargo.toml
+++ b/examples/blocktad-merging/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "blocktad-merging"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+germterm = { path = "../../germterm" }

--- a/examples/blocktad-merging/src/main.rs
+++ b/examples/blocktad-merging/src/main.rs
@@ -1,0 +1,51 @@
+use germterm::{
+    color::Color,
+    crossterm::event::{Event, KeyCode, KeyEvent},
+    draw::{Layer, draw_blocktad, fill_screen},
+    engine::{Engine, end_frame, exit_cleanup, init, start_frame},
+    input::poll_input,
+};
+
+use std::io;
+
+pub const TERM_COLS: u16 = 40;
+pub const TERM_ROWS: u16 = 20;
+
+fn main() -> io::Result<()> {
+    let mut engine: Engine = Engine::new(TERM_COLS, TERM_ROWS)
+        .title("octad-merging")
+        .limit_fps(240);
+
+    let mut layer = Layer::new(&mut engine, 0);
+
+    init(&mut engine)?;
+
+    'game_loop: loop {
+        start_frame(&mut engine);
+
+        for event in poll_input() {
+            if let Event::Key(KeyEvent {
+                code: KeyCode::Char('q'),
+                ..
+            }) = event
+            {
+                break 'game_loop;
+            }
+        }
+
+        fill_screen(&mut layer, Color::BLACK);
+
+        draw_blocktad(&mut layer, 0.0, 0.0, Color::RED);
+        draw_blocktad(&mut layer, 0.5, 0.25, Color::RED);
+        draw_blocktad(&mut layer, 0.5, 0.75, Color::RED);
+
+        draw_blocktad(&mut layer, 1.0, 0.5, Color::CYAN);
+
+        draw_blocktad(&mut layer, 2.5, 0.25, Color::GREEN);
+
+        end_frame(&mut engine)?;
+    }
+
+    exit_cleanup(&mut engine)?;
+    Ok(())
+}

--- a/germterm/README.md
+++ b/germterm/README.md
@@ -31,7 +31,7 @@ It renders in real time, adds support for the alpha channel, adds multiple drawi
 ## Getting started
 
 Add `germterm` as a dependency:
-```
+```plain_text,no_run
 cargo add germterm
 ```
 

--- a/germterm/src/draw.rs
+++ b/germterm/src/draw.rs
@@ -40,6 +40,26 @@ use crate::{
     color::Color, engine::Engine, fps_counter::get_fps, frame::DrawCall, rich_text::RichText,
 };
 
+#[rustfmt::skip]
+pub(crate) static BLOCKTAD_CHAR_LUT: [char; 256] = [
+    ' ', '𜺨', '𜺫', '🮂', '𜴀', '▘', '𜴁', '𜴂', '𜴃', '𜴄', '▝', '𜴅', '𜴆', '𜴇', '𜴈', '▀',
+    '𜴉', '𜴊', '𜴋', '𜴌', '🯦', '𜴍', '𜴎', '𜴏', '𜴐', '𜴑', '𜴒', '𜴓', '𜴔', '𜴕', '𜴖', '𜴗',
+    '𜴘', '𜴙', '𜴚', '𜴛', '𜴜', '𜴝', '𜴞', '𜴟', '🯧', '𜴠', '𜴡', '𜴢', '𜴣', '𜴤', '𜴥', '𜴦',
+    '𜴧', '𜴨', '𜴩', '𜴪', '𜴫', '𜴬', '𜴭', '𜴮', '𜴯', '𜴰', '𜴱', '𜴲', '𜴳', '𜴴', '𜴵', '🮅',
+    '𜺣', '𜴶', '𜴷', '𜴸', '𜴹', '𜴺', '𜴻', '𜴼', '𜴽', '𜴾', '𜴿', '𜵀', '𜵁', '𜵂', '𜵃', '𜵄',
+    '▖', '𜵅', '𜵆', '𜵇', '𜵈', '▌', '𜵉', '𜵊', '𜵋', '𜵌', '▞', '𜵍', '𜵎', '𜵏', '𜵐', '▛',
+    '𜵑', '𜵒', '𜵓', '𜵔', '𜵕', '𜵖', '𜵗', '𜵘', '𜵙', '𜵚', '𜵛', '𜵜', '𜵝', '𜵞', '𜵟', '𜵠',
+    '𜵡', '𜵢', '𜵣', '𜵤', '𜵥', '𜵦', '𜵧', '𜵨', '𜵩', '𜵪', '𜵫', '𜵬', '𜵭', '𜵮', '𜵯', '𜵰',
+    '𜺠', '𜵱', '𜵲', '𜵳', '𜵴', '𜵵', '𜵶', '𜵷', '𜵸', '𜵹', '𜵺', '𜵻', '𜵼', '𜵽', '𜵾', '𜵿',
+    '𜶀', '𜶁', '𜶂', '𜶃', '𜶄', '𜶅', '𜶆', '𜶇', '𜶈', '𜶉', '𜶊', '𜶋', '𜶌', '𜶍', '𜶎', '𜶏',
+    '▗', '𜶐', '𜶑', '𜶒', '𜶓', '▚', '𜶔', '𜶕', '𜶖', '𜶗', '▐', '𜶘', '𜶙', '𜶚', '𜶛', '▜',
+    '𜶜', '𜶝', '𜶞', '𜶟', '𜶠', '𜶡', '𜶢', '𜶣', '𜶤', '𜶥', '𜶦', '𜶧', '𜶨', '𜶩', '𜶪', '𜶫',
+    '▂', '𜶬', '𜶭', '𜶮', '𜶯', '𜶰', '𜶱', '𜶲', '𜶳', '𜶴', '𜶵', '𜶶', '𜶷', '𜶸', '𜶹', '𜶺',
+    '𜶻', '𜶼', '𜶽', '𜶾', '𜶿', '𜷀', '𜷁', '𜷂', '𜷃', '𜷄', '𜷅', '𜷆', '𜷇', '𜷈', '𜷉', '𜷊',
+    '𜷋', '𜷌', '𜷍', '𜷎', '𜷏', '𜷐', '𜷑', '𜷒', '𜷓', '𜷔', '𜷕', '𜷖', '𜷗', '𜷘', '𜷙', '𜷚',
+    '▄', '𜷛', '𜷜', '𜷝', '𜷞', '▙', '𜷟', '𜷠', '𜷡', '𜷢', '▟', '𜷣', '▆', '𜷤', '𜷥', '█',
+];
+
 /// A handle to a drawing layer.
 ///
 /// Passed into drawing functions, specifies to which layer the contents will be drawn.
@@ -172,6 +192,40 @@ pub fn draw_octad(layer: &mut Layer, x: f32, y: f32, color: Color) {
     internal::draw_octad(draw_queue, x, y, color);
 }
 
+/// Draws a single blocktad at the specified sub-cell position.
+///
+/// Blocktads are represented by the 2x4 square blocky characters from the
+/// [Symbols for Legacy Computing Supplement](https://en.wikipedia.org/wiki/Symbols_for_Legacy_Computing_Supplement) Unicode block.
+/// The character will be drawn in one of the 8 possible sub-positions of a cell,
+/// based on the passed floating point coordinates.
+///
+/// The coordinate space is based on cols and rows (`x` and `y`), just like the rest of the drawing API.
+///
+/// When drawing multiple blocktads to the same cell, at differing sub-positions, the blocktads will merge into a single character representing both.
+/// Merged blocktads possess a technical limitation of having to share the same `fg` color.
+/// Because of this, the entire merged blocktad cluster inherits the `fg` color of the last drawn blocktad in the cell.
+///
+/// # Example
+/// ```rust,no_run
+/// # use germterm::{draw::{Layer, draw_blocktad}, engine::Engine, color::Color};
+/// let mut engine = Engine::new(40, 20);
+/// let mut layer = Layer::new(&mut engine, 0);
+///
+/// // The following blocktads would occupy the same cell,
+/// // resulting in a merged blocktad cluster being drawn
+/// draw_blocktad(&mut layer, 3.0, 4.0, Color::GREEN);
+/// draw_blocktad(&mut layer, 3.0, 4.5, Color::GREEN);
+/// ```
+///
+/// /// # Notes
+/// The characters may not show up on all fonts, as the [Symbols for Legacy Computing Supplement](https://en.wikipedia.org/wiki/Symbols_for_Legacy_Computing_Supplement)
+/// Unicode block is a relatively recent addition. Use with caution.
+pub fn draw_blocktad(layer: &mut Layer, x: f32, y: f32, color: Color) {
+    let engine: &mut Engine = unsafe { &mut *layer.engine_ptr };
+    let draw_queue: &mut Vec<DrawCall> = &mut engine.frame.layered_draw_queue[layer.index];
+    internal::draw_blocktad(draw_queue, x, y, color);
+}
+
 /// Draws a single twoxel at the specified sub-cell position.
 ///
 /// A single twoxel is represented by one of the half block characters (`▀` or `▄`) from the [Block Elements unicode block](https://en.wikipedia.org/wiki/Block_Elements).
@@ -226,6 +280,7 @@ pub(crate) mod internal {
 
     use crate::{
         color::Color,
+        draw::BLOCKTAD_CHAR_LUT,
         frame::DrawCall,
         rich_text::{Attributes, RichText},
     };
@@ -267,6 +322,25 @@ pub(crate) mod internal {
         for row in 0..height {
             draw_text(draw_queue, x, y + row, row_rich_text.clone())
         }
+    }
+
+    pub fn draw_blocktad(draw_queue: &mut Vec<DrawCall>, x: f32, y: f32, color: Color) {
+        let cell_x: i16 = x.floor() as i16;
+        let cell_y: i16 = y.floor() as i16;
+
+        let sub_x: usize = (((x - cell_x as f32) * 2.0).floor().clamp(0.0, 1.0)) as usize;
+        let sub_y: usize = (((y - cell_y as f32) * 4.0).floor().clamp(0.0, 3.0)) as usize;
+
+        let offset: usize = sub_y * 2 + sub_x;
+        let mask: usize = 1 << offset;
+
+        let blocktad_char: char = BLOCKTAD_CHAR_LUT[mask];
+
+        let rich_text: RichText = RichText::new(blocktad_char.to_string())
+            .fg(color)
+            .attributes(Attributes::BLOCKTAD);
+
+        draw_text(draw_queue, cell_x, cell_y, rich_text);
     }
 
     pub fn draw_octad(draw_queue: &mut Vec<DrawCall>, x: f32, y: f32, color: Color) {

--- a/germterm/src/rich_text.rs
+++ b/germterm/src/rich_text.rs
@@ -25,14 +25,28 @@ bitflags! {
         /// This flag is **not part of the public API**.
         /// Using it may cause rendering glitches.
         ///
-        /// Incompatible with [`Attributes::OCTAD`]
+        /// Incompatible with:
+        /// - [`Attributes::OCTAD`]
+        /// - [`Attributes::BLOCKTAD`]
         const TWOXEL        = 0b_00010000;
         /// # WARNING
         /// This flag is **not part of the public API**.
         /// Using it may cause rendering glitches.
         ///
-        /// Incompatible with [`Attributes::TWOXEL`]
+        /// Incompatible with:
+        /// - [`Attributes::TWOXEL`]
+        /// - [`Attributes::BLOCKTAD`]
         const OCTAD         = 0b_00100000;
+        /// # WARNING
+        /// This flag is **not part of the public API**.
+        /// Using it may cause rendering glitches.
+        ///
+        /// Incompatible with:
+        /// - [`Attributes::TWOXEL`]
+        /// - [`Attributes::OCTAD`]
+        const BLOCKTAD      = 0b_01000000;
+
+
     }
 }
 


### PR DESCRIPTION
Implements the blocktad drawing type, accessible via `draw::draw_blocktad`.

Closes #4
