### PR TITLE
Rework layer API

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -1,5 +1,7 @@
 # 0.4.0
 
+- `Layer` is now reserved for internal use, the new public API uses `LayerIndex` and the `create_layer()` factory
+- Changed drawing function first args from `&mut Layer` to `&mut Engine` and `LayerIndex`
 - Removed `Color::NO_COLOR` in favor of `Attributes::NO_FG_COLOR` and `Attributes::NO_BG_COLOR`
 
 # 0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@
 
 ### 🛠 Changed
 
+- Reworked the layer API into a more memory safe form
 - Improved stability and performance of the diffing step ([@airblast-dev](https://github.com/airblast-dev))
-- Removed unnecessary allocations (by [@airblast-dev](https://github.com/airblast-dev))
+- Removed unnecessary allocations ([@airblast-dev](https://github.com/airblast-dev))
 
 ### ⚠ Breaking
 
+- `Layer` is now reserved for internal use, the new public API uses `LayerIndex` and the `create_layer()` factory
+- Changed drawing function first args from `&mut Layer` to `&mut Engine` and `LayerIndex`
 - Removed `Color::NO_COLOR` in favor of `Attributes::NO_FG_COLOR` and `Attributes::NO_BG_COLOR`
 
 # 0.3.0

--- a/README.md
+++ b/README.md
@@ -31,23 +31,24 @@ It renders in real time, adds support for the alpha channel, adds multiple drawi
 ## Getting started
 
 Add `germterm` as a dependency:
+
 ```plain_text,no_run
 cargo add germterm
 ```
 
 ```rust,no_run
 use germterm::{
-    color::Color,
     crossterm::event::{Event, KeyCode, KeyEvent},
-    draw::{Layer, draw_text, fill_screen, draw_fps_counter},
+    draw::{draw_fps_counter, draw_text},
     engine::{Engine, end_frame, exit_cleanup, init, start_frame},
     input::poll_input,
+    layer::create_layer,
 };
 use std::io;
 
 fn main() -> io::Result<()> {
     let mut engine = Engine::new(40, 20);
-    let mut layer = Layer::new(&mut engine, 0);
+    let layer = create_layer(&mut engine, 0);
 
     // Initialize engine and layers
     init(&mut engine)?;
@@ -68,8 +69,8 @@ fn main() -> io::Result<()> {
         }
 
         // Draw contents
-        draw_text(&mut layer, 14, 9, "Hello world!");
-        draw_fps_counter(&mut layer, 0, 0);
+        draw_text(&mut engine, layer, 14, 9, "Hello, Ferris!");
+        draw_fps_counter(&mut engine, layer, 0, 0);
 
         // End the frame
         end_frame(&mut engine)?;

--- a/examples/blocktad-merging/src/main.rs
+++ b/examples/blocktad-merging/src/main.rs
@@ -1,9 +1,10 @@
 use germterm::{
     color::Color,
     crossterm::event::{Event, KeyCode, KeyEvent},
-    draw::{Layer, draw_blocktad, fill_screen},
+    draw::{draw_blocktad, fill_screen},
     engine::{Engine, end_frame, exit_cleanup, init, start_frame},
     input::poll_input,
+    layer::create_layer,
 };
 
 use std::io;
@@ -16,7 +17,7 @@ fn main() -> io::Result<()> {
         .title("blocktad-merging")
         .limit_fps(240);
 
-    let mut layer = Layer::new(&mut engine, 0);
+    let layer = create_layer(&mut engine, 0);
 
     init(&mut engine)?;
 
@@ -33,15 +34,15 @@ fn main() -> io::Result<()> {
             }
         }
 
-        fill_screen(&mut layer, Color::BLACK);
+        fill_screen(&mut engine, layer, Color::BLACK);
 
-        draw_blocktad(&mut layer, 0.0, 0.0, Color::RED);
-        draw_blocktad(&mut layer, 0.5, 0.25, Color::RED);
-        draw_blocktad(&mut layer, 0.5, 0.75, Color::RED);
+        draw_blocktad(&mut engine, layer, 0.0, 0.0, Color::RED);
+        draw_blocktad(&mut engine, layer, 0.5, 0.25, Color::RED);
+        draw_blocktad(&mut engine, layer, 0.5, 0.75, Color::RED);
 
-        draw_blocktad(&mut layer, 1.0, 0.5, Color::CYAN);
+        draw_blocktad(&mut engine, layer, 1.0, 0.5, Color::CYAN);
 
-        draw_blocktad(&mut layer, 2.5, 0.25, Color::GREEN);
+        draw_blocktad(&mut engine, layer, 2.5, 0.25, Color::GREEN);
 
         end_frame(&mut engine)?;
     }

--- a/examples/erase-contents/src/main.rs
+++ b/examples/erase-contents/src/main.rs
@@ -1,9 +1,10 @@
 use germterm::{
     color::Color,
     crossterm::event::{Event, KeyCode, KeyEvent},
-    draw::{Layer, draw_text, erase_rect, fill_screen},
+    draw::{draw_text, erase_rect, fill_screen},
     engine::{Engine, end_frame, exit_cleanup, init, start_frame},
     input::poll_input,
+    layer::create_layer,
     rich_text::RichText,
 };
 use std::io;
@@ -13,13 +14,13 @@ const TERM_ROWS: u16 = 20;
 
 fn main() -> io::Result<()> {
     let mut engine = Engine::new(TERM_COLS, TERM_ROWS);
-    let mut layer = Layer::new(&mut engine, 0);
+    let layer = create_layer(&mut engine, 0);
 
     init(&mut engine)?;
 
     'update_loop: loop {
         start_frame(&mut engine);
-        fill_screen(&mut layer, Color::BLACK);
+        fill_screen(&mut engine, layer, Color::BLACK);
 
         for event in poll_input() {
             if let Event::Key(KeyEvent {
@@ -38,7 +39,8 @@ fn main() -> io::Result<()> {
                 "/-"
             };
             draw_text(
-                &mut layer,
+                &mut engine,
+                layer,
                 0,
                 y_offset as i16,
                 RichText::new(text.repeat(TERM_COLS as usize / 2))
@@ -46,7 +48,7 @@ fn main() -> io::Result<()> {
             );
         }
 
-        erase_rect(&mut layer, 10, 5, 20, 10);
+        erase_rect(&mut engine, layer, 10, 5, 20, 10);
 
         end_frame(&mut engine)?;
     }

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,20 +1,24 @@
 use germterm::{
     crossterm::event::{Event, KeyCode, KeyEvent},
-    draw::{Layer, draw_fps_counter, draw_text},
+    draw::{draw_fps_counter, draw_text},
     engine::{Engine, end_frame, exit_cleanup, init, start_frame},
     input::poll_input,
+    layer::create_layer,
 };
 use std::io;
 
 fn main() -> io::Result<()> {
-    let mut engine = Engine::new(40, 20).limit_fps(0);
-    let mut layer = Layer::new(&mut engine, 0);
+    let mut engine = Engine::new(40, 20);
+    let layer = create_layer(&mut engine, 0);
 
+    // Initialize engine and layers
     init(&mut engine)?;
 
     'update_loop: loop {
+        // Start the frame
         start_frame(&mut engine);
 
+        // 'q' to exit the program
         for event in poll_input() {
             if let Event::Key(KeyEvent {
                 code: KeyCode::Char('q'),
@@ -26,12 +30,14 @@ fn main() -> io::Result<()> {
         }
 
         // Draw contents
-        draw_text(&mut layer, 14, 9, "Hello world!");
-        draw_fps_counter(&mut layer, 0, 0);
+        draw_text(&mut engine, layer, 14, 9, "Hello, Ferris!");
+        draw_fps_counter(&mut engine, layer, 0, 0);
 
+        // End the frame
         end_frame(&mut engine)?;
     }
 
+    // Restore terminal before exiting
     exit_cleanup(&mut engine)?;
     Ok(())
 }

--- a/examples/octad-merging/src/main.rs
+++ b/examples/octad-merging/src/main.rs
@@ -1,9 +1,10 @@
 use germterm::{
     color::Color,
     crossterm::event::{Event, KeyCode, KeyEvent},
-    draw::{Layer, draw_octad, fill_screen},
+    draw::{draw_octad, fill_screen},
     engine::{Engine, end_frame, exit_cleanup, init, start_frame},
     input::poll_input,
+    layer::create_layer,
 };
 
 use std::io;
@@ -16,7 +17,7 @@ fn main() -> io::Result<()> {
         .title("octad-merging")
         .limit_fps(240);
 
-    let mut layer = Layer::new(&mut engine, 0);
+    let layer = create_layer(&mut engine, 0);
 
     init(&mut engine)?;
 
@@ -33,13 +34,13 @@ fn main() -> io::Result<()> {
             }
         }
 
-        fill_screen(&mut layer, Color::BLACK);
+        fill_screen(&mut engine, layer, Color::BLACK);
 
         // Those 3 should all merge into a single braille char in the cell
         // The color should be GREEN as it's set of the topmost merge's color value
-        draw_octad(&mut layer, 0.1, 0.0, Color::RED);
-        draw_octad(&mut layer, 0.9, 0.0, Color::BLUE);
-        draw_octad(&mut layer, 0.9, 0.25, Color::GREEN);
+        draw_octad(&mut engine, layer, 0.1, 0.0, Color::RED);
+        draw_octad(&mut engine, layer, 0.9, 0.0, Color::BLUE);
+        draw_octad(&mut engine, layer, 0.9, 0.25, Color::GREEN);
 
         end_frame(&mut engine)?;
     }

--- a/examples/octad-particles/src/main.rs
+++ b/examples/octad-particles/src/main.rs
@@ -1,9 +1,10 @@
 use germterm::{
     color::{Color, ColorGradient, GradientStop},
     crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind},
-    draw::{Layer, draw_fps_counter, draw_text},
+    draw::{draw_fps_counter, draw_text},
     engine::{Engine, end_frame, exit_cleanup, init, start_frame},
     input::poll_input,
+    layer::create_layer,
     particle::{
         ParticleColor, ParticleEmitter, ParticleEmitterShape, ParticleSpec, spawn_particles,
     },
@@ -20,8 +21,8 @@ fn main() -> io::Result<()> {
         .title("octad-particles")
         .limit_fps(0);
 
-    let mut main_layer = Layer::new(&mut engine, 0);
-    let mut text_top_layer = Layer::new(&mut engine, 1);
+    let main_layer = create_layer(&mut engine, 0);
+    let text_top_layer = create_layer(&mut engine, 1);
 
     init(&mut engine)?;
     'game_loop: loop {
@@ -65,7 +66,8 @@ fn main() -> io::Result<()> {
                 let y_b: f32 = TERM_ROWS as f32 * 0.7;
 
                 spawn_particles(
-                    &mut main_layer,
+                    &mut engine,
+                    main_layer,
                     rng.random_range(x_a..=x_b),
                     rng.random_range(y_a..=y_b),
                     &spec,
@@ -75,7 +77,8 @@ fn main() -> io::Result<()> {
         }
 
         draw_text(
-            &mut text_top_layer,
+            &mut engine,
+            text_top_layer,
             26,
             (TERM_ROWS / 2) as i16,
             RichText::new("Press W to spawn particles!")
@@ -83,7 +86,7 @@ fn main() -> io::Result<()> {
                 .with_attributes(Attributes::BOLD),
         );
 
-        draw_fps_counter(&mut text_top_layer, 0, 0);
+        draw_fps_counter(&mut engine, text_top_layer, 0, 0);
 
         end_frame(&mut engine)?;
     }

--- a/examples/particle-benchmark/src/main.rs
+++ b/examples/particle-benchmark/src/main.rs
@@ -1,12 +1,12 @@
 use std::io;
 
-use germterm::draw::Layer;
 use germterm::{
     color::Color,
     crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind},
     draw::draw_fps_counter,
     engine::{Engine, end_frame, exit_cleanup, init, start_frame},
     input::poll_input,
+    layer::create_layer,
     particle::{ParticleColor, ParticleEmitter, ParticleSpec, spawn_particles},
 };
 
@@ -19,7 +19,7 @@ fn main() -> io::Result<()> {
         .title("particle-benchmark")
         .limit_fps(240);
 
-    let mut layer = Layer::new(&mut engine, 0);
+    let layer = create_layer(&mut engine, 0);
 
     init(&mut engine)?;
 
@@ -38,7 +38,8 @@ fn main() -> io::Result<()> {
                     ..
                 }) => {
                     spawn_particles(
-                        &mut layer,
+                        &mut engine,
+                        layer,
                         TERM_COLS as f32 * 0.5,
                         TERM_ROWS as f32 * 0.5,
                         &ParticleSpec {
@@ -57,7 +58,7 @@ fn main() -> io::Result<()> {
             }
         }
 
-        draw_fps_counter(&mut layer, 0, 1);
+        draw_fps_counter(&mut engine, layer, 0, 1);
 
         end_frame(&mut engine)?;
     }

--- a/examples/twoxel-snake/src/main.rs
+++ b/examples/twoxel-snake/src/main.rs
@@ -1,10 +1,11 @@
 use germterm::{
     color::{Color, ColorGradient, GradientStop, sample_gradient},
     crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind},
-    draw::{Layer, draw_octad, draw_text, draw_twoxel},
+    draw::{draw_octad, draw_text, draw_twoxel},
     engine::{Engine, end_frame, exit_cleanup, init, start_frame},
     fps_counter::get_fps,
     input::poll_input,
+    layer::{LayerIndex, create_layer},
     particle::{ParticleColor, ParticleEmitter, ParticleSpec, spawn_particles},
     rich_text::{Attributes, RichText},
 };
@@ -29,9 +30,9 @@ fn main() -> io::Result<()> {
         .title("twoxel-snake")
         .limit_fps(0);
 
-    let mut layer_0 = Layer::new(&mut engine, 0);
-    let mut layer_1 = Layer::new(&mut engine, 1);
-    let mut layer_2 = Layer::new(&mut engine, 2);
+    let layer_0 = create_layer(&mut engine, 0);
+    let layer_1 = create_layer(&mut engine, 1);
+    let layer_2 = create_layer(&mut engine, 2);
 
     let bg_decoration_color: Color = Color(0x45475aff);
     let movement_speed: f32 = 20.0;
@@ -113,7 +114,8 @@ fn main() -> io::Result<()> {
                 if segments.contains(&new_head) {
                     game_state = GameState::GameOver;
                     spawn_death_explosion(
-                        &mut layer_1,
+                        &mut engine,
+                        layer_1,
                         new_head.0 as f32 + 0.5,
                         (new_head.1 as f32 + 0.5) * 0.5,
                     );
@@ -122,13 +124,15 @@ fn main() -> io::Result<()> {
 
                 if new_head == apple_pos {
                     spawn_explosion(
-                        &mut layer_0,
+                        &mut engine,
+                        layer_0,
                         apple_pos.0 as f32 + 0.5,
                         (apple_pos.1 as f32 + 0.5) * 0.5,
                     );
                     apple_pos = random_pos();
                     spawn_apple_create_particles(
-                        &mut layer_0,
+                        &mut engine,
+                        layer_0,
                         (apple_pos.0 as f32) + 0.5,
                         ((apple_pos.1 as f32) + 0.5) * 0.5,
                     );
@@ -139,7 +143,7 @@ fn main() -> io::Result<()> {
         }
 
         let mut draw = |x: f32, y: f32| {
-            draw_octad(&mut layer_2, x, y, bg_decoration_color);
+            draw_octad(&mut engine, layer_2, x, y, bg_decoration_color);
         };
 
         // --- Horizontal borders ---
@@ -168,7 +172,8 @@ fn main() -> io::Result<()> {
 
         // --- Draw apple ---
         draw_twoxel(
-            &mut layer_2,
+            &mut engine,
+            layer_2,
             apple_pos.0 as f32,
             apple_pos.1 as f32 * 0.5,
             Color::RED,
@@ -179,7 +184,8 @@ fn main() -> io::Result<()> {
             let t: f32 = i as f32 / segments.len() as f32;
             // Multiplying the y axis by 0.5 here, as terminal cells usually have a 1:2 width to height ratio
             draw_twoxel(
-                &mut layer_2,
+                &mut engine,
+                layer_2,
                 segment.0 as f32,
                 segment.1 as f32 * 0.5,
                 sample_gradient(&snake_color_gradient, t),
@@ -189,7 +195,8 @@ fn main() -> io::Result<()> {
         // --- FPS Counter
         let fps_text: String = format!("UNCAPPED FPS: {:2.0}", get_fps(&engine));
         draw_text(
-            &mut layer_1,
+            &mut engine,
+            layer_1,
             10,
             1,
             RichText::new(fps_text)
@@ -199,7 +206,8 @@ fn main() -> io::Result<()> {
 
         if matches!(game_state, GameState::GameOver) {
             draw_text(
-                &mut layer_2,
+                &mut engine,
+                layer_2,
                 (TERM_COLS / 2 - 6) as i16,
                 (TERM_ROWS / 2 - 1) as i16,
                 RichText::new("GAME OVER!")
@@ -223,8 +231,9 @@ fn random_pos() -> (i16, i16) {
     )
 }
 
-fn spawn_explosion(layer: &mut Layer, x: f32, y: f32) {
+fn spawn_explosion(engine: &mut Engine, layer: LayerIndex, x: f32, y: f32) {
     spawn_particles(
+        engine,
         layer,
         x,
         y,
@@ -245,8 +254,9 @@ fn spawn_explosion(layer: &mut Layer, x: f32, y: f32) {
     );
 }
 
-fn spawn_apple_create_particles(layer: &mut Layer, x: f32, y: f32) {
+fn spawn_apple_create_particles(engine: &mut Engine, layer: LayerIndex, x: f32, y: f32) {
     spawn_particles(
+        engine,
         layer,
         x,
         y,
@@ -266,8 +276,9 @@ fn spawn_apple_create_particles(layer: &mut Layer, x: f32, y: f32) {
     );
 }
 
-fn spawn_death_explosion(layer: &mut Layer, x: f32, y: f32) {
+fn spawn_death_explosion(engine: &mut Engine, layer: LayerIndex, x: f32, y: f32) {
     spawn_particles(
+        engine,
         layer,
         x,
         y,

--- a/examples/twoxel-tester/src/main.rs
+++ b/examples/twoxel-tester/src/main.rs
@@ -1,9 +1,10 @@
 use germterm::{
     color::Color,
     crossterm::event::{Event, KeyCode, KeyEvent},
-    draw::{Layer, draw_fps_counter, draw_rect, draw_text, draw_twoxel},
+    draw::{draw_fps_counter, draw_rect, draw_text, draw_twoxel},
     engine::{Engine, end_frame, exit_cleanup, init, start_frame},
     input::poll_input,
+    layer::{LayerIndex, create_layer},
     rich_text::RichText,
 };
 use std::io;
@@ -14,7 +15,7 @@ pub const TERM_ROWS: u16 = 30;
 fn main() -> io::Result<()> {
     let mut engine: Engine = Engine::new(TERM_COLS, TERM_ROWS).title("twoxel-tester");
 
-    let mut layer = Layer::new(&mut engine, 0);
+    let layer = create_layer(&mut engine, 0);
 
     init(&mut engine)?;
     'game_loop: loop {
@@ -31,20 +32,21 @@ fn main() -> io::Result<()> {
         }
 
         draw_rect(
-            &mut layer,
+            &mut engine,
+            layer,
             0,
             9,
             TERM_COLS as i16,
             9,
             Color::BLACK.with_alpha(127),
         );
-        draw_rect(&mut layer, 0, 18, TERM_COLS as i16, 9, Color::BLACK);
+        draw_rect(&mut engine, layer, 0, 18, TERM_COLS as i16, 9, Color::BLACK);
 
-        draw_test_case(&mut layer, 15.0, 1.0);
-        draw_test_case(&mut layer, 15.0, 10.0);
-        draw_test_case(&mut layer, 15.0, 19.0);
+        draw_test_case(&mut engine, layer, 15.0, 1.0);
+        draw_test_case(&mut engine, layer, 15.0, 10.0);
+        draw_test_case(&mut engine, layer, 15.0, 19.0);
 
-        draw_fps_counter(&mut layer, 0, 0);
+        draw_fps_counter(&mut engine, layer, 0, 0);
         end_frame(&mut engine)?;
     }
 
@@ -52,32 +54,41 @@ fn main() -> io::Result<()> {
     Ok(())
 }
 
-fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
+fn draw_test_case(engine: &mut Engine, layer: LayerIndex, x: f32, y: f32) {
     let alpha_value: u8 = 60;
 
     // 1. Single twoxel (top)
     draw_text(
+        engine,
         layer,
         x as i16,
         y as i16,
         RichText::new("1").with_fg(Color::DARK_GRAY),
     );
 
-    draw_twoxel(layer, x, y + 2.0, Color::RED);
+    draw_twoxel(engine, layer, x, y + 2.0, Color::RED);
 
-    draw_twoxel(layer, x, y + 4.0, Color::RED.with_alpha(alpha_value));
+    draw_twoxel(
+        engine,
+        layer,
+        x,
+        y + 4.0,
+        Color::RED.with_alpha(alpha_value),
+    );
 
     // 2. Single twoxel (bottom)
     draw_text(
+        engine,
         layer,
         x as i16 + 2,
         y as i16,
         RichText::new("2").with_fg(Color::DARK_GRAY),
     );
 
-    draw_twoxel(layer, x + 2.0, y + 2.5, Color::GREEN);
+    draw_twoxel(engine, layer, x + 2.0, y + 2.5, Color::GREEN);
 
     draw_twoxel(
+        engine,
         layer,
         x + 2.0,
         y + 4.5,
@@ -86,17 +97,25 @@ fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
 
     // 3. Merged twoxels
     draw_text(
+        engine,
         layer,
         x as i16 + 4,
         y as i16,
         RichText::new("3").with_fg(Color::DARK_GRAY),
     );
 
-    draw_twoxel(layer, x + 4.0, y + 2.0, Color::RED);
-    draw_twoxel(layer, x + 4.0, y + 2.5, Color::GREEN);
+    draw_twoxel(engine, layer, x + 4.0, y + 2.0, Color::RED);
+    draw_twoxel(engine, layer, x + 4.0, y + 2.5, Color::GREEN);
 
-    draw_twoxel(layer, x + 4.0, y + 4.0, Color::RED.with_alpha(alpha_value));
     draw_twoxel(
+        engine,
+        layer,
+        x + 4.0,
+        y + 4.0,
+        Color::RED.with_alpha(alpha_value),
+    );
+    draw_twoxel(
+        engine,
         layer,
         x + 4.0,
         y + 4.5,
@@ -105,24 +124,33 @@ fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
 
     // 4. Merged twoxels + redrawing at the top position
     draw_text(
+        engine,
         layer,
         x as i16 + 6,
         y as i16,
         RichText::new("4").with_fg(Color::DARK_GRAY),
     );
 
-    draw_twoxel(layer, x + 6.0, y + 2.0, Color::RED);
-    draw_twoxel(layer, x + 6.0, y + 2.5, Color::GREEN);
-    draw_twoxel(layer, x + 6.0, y + 2.0, Color::LIGHT_GRAY);
+    draw_twoxel(engine, layer, x + 6.0, y + 2.0, Color::RED);
+    draw_twoxel(engine, layer, x + 6.0, y + 2.5, Color::GREEN);
+    draw_twoxel(engine, layer, x + 6.0, y + 2.0, Color::LIGHT_GRAY);
 
-    draw_twoxel(layer, x + 6.0, y + 4.0, Color::RED.with_alpha(alpha_value));
     draw_twoxel(
+        engine,
+        layer,
+        x + 6.0,
+        y + 4.0,
+        Color::RED.with_alpha(alpha_value),
+    );
+    draw_twoxel(
+        engine,
         layer,
         x + 6.0,
         y + 4.5,
         Color::GREEN.with_alpha(alpha_value),
     );
     draw_twoxel(
+        engine,
         layer,
         x + 6.0,
         y + 4.0,
@@ -131,24 +159,33 @@ fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
 
     // 5. Merged twoxels + redrawing at the bottom position
     draw_text(
+        engine,
         layer,
         x as i16 + 8,
         y as i16,
         RichText::new("5").with_fg(Color::DARK_GRAY),
     );
 
-    draw_twoxel(layer, x + 8.0, y + 2.0, Color::RED);
-    draw_twoxel(layer, x + 8.0, y + 2.5, Color::GREEN);
-    draw_twoxel(layer, x + 8.0, y + 2.5, Color::LIGHT_GRAY);
+    draw_twoxel(engine, layer, x + 8.0, y + 2.0, Color::RED);
+    draw_twoxel(engine, layer, x + 8.0, y + 2.5, Color::GREEN);
+    draw_twoxel(engine, layer, x + 8.0, y + 2.5, Color::LIGHT_GRAY);
 
-    draw_twoxel(layer, x + 8.0, y + 4.0, Color::RED.with_alpha(alpha_value));
     draw_twoxel(
+        engine,
+        layer,
+        x + 8.0,
+        y + 4.0,
+        Color::RED.with_alpha(alpha_value),
+    );
+    draw_twoxel(
+        engine,
         layer,
         x + 8.0,
         y + 4.5,
         Color::GREEN.with_alpha(alpha_value),
     );
     draw_twoxel(
+        engine,
         layer,
         x + 8.0,
         y + 4.5,
@@ -157,24 +194,33 @@ fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
 
     // 6. Same as 4. but reverse top & bottom
     draw_text(
+        engine,
         layer,
         x as i16 + 10,
         y as i16,
         RichText::new("6").with_fg(Color::DARK_GRAY),
     );
 
-    draw_twoxel(layer, x + 10.0, y + 2.5, Color::GREEN);
-    draw_twoxel(layer, x + 10.0, y + 2.0, Color::RED);
-    draw_twoxel(layer, x + 10.0, y + 2.0, Color::LIGHT_GRAY);
+    draw_twoxel(engine, layer, x + 10.0, y + 2.5, Color::GREEN);
+    draw_twoxel(engine, layer, x + 10.0, y + 2.0, Color::RED);
+    draw_twoxel(engine, layer, x + 10.0, y + 2.0, Color::LIGHT_GRAY);
 
     draw_twoxel(
+        engine,
         layer,
         x + 10.0,
         y + 4.5,
         Color::GREEN.with_alpha(alpha_value),
     );
-    draw_twoxel(layer, x + 10.0, y + 4.0, Color::RED.with_alpha(alpha_value));
     draw_twoxel(
+        engine,
+        layer,
+        x + 10.0,
+        y + 4.0,
+        Color::RED.with_alpha(alpha_value),
+    );
+    draw_twoxel(
+        engine,
         layer,
         x + 10.0,
         y + 4.0,
@@ -183,24 +229,33 @@ fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
 
     // 7. Same as 5. but reverse top & bottom
     draw_text(
+        engine,
         layer,
         x as i16 + 12,
         y as i16,
         RichText::new("7").with_fg(Color::DARK_GRAY),
     );
 
-    draw_twoxel(layer, x + 12.0, y + 2.5, Color::GREEN);
-    draw_twoxel(layer, x + 12.0, y + 2.0, Color::RED);
-    draw_twoxel(layer, x + 12.0, y + 2.5, Color::LIGHT_GRAY);
+    draw_twoxel(engine, layer, x + 12.0, y + 2.5, Color::GREEN);
+    draw_twoxel(engine, layer, x + 12.0, y + 2.0, Color::RED);
+    draw_twoxel(engine, layer, x + 12.0, y + 2.5, Color::LIGHT_GRAY);
 
     draw_twoxel(
+        engine,
         layer,
         x + 12.0,
         y + 4.5,
         Color::GREEN.with_alpha(alpha_value),
     );
-    draw_twoxel(layer, x + 12.0, y + 4.0, Color::RED.with_alpha(alpha_value));
     draw_twoxel(
+        engine,
+        layer,
+        x + 12.0,
+        y + 4.0,
+        Color::RED.with_alpha(alpha_value),
+    );
+    draw_twoxel(
+        engine,
         layer,
         x + 12.0,
         y + 4.5,
@@ -209,6 +264,7 @@ fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
 
     // --- Intended visual testers ---
     draw_text(
+        engine,
         layer,
         x as i16 - 10,
         y as i16 + 2,
@@ -216,6 +272,7 @@ fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
     );
 
     draw_text(
+        engine,
         layer,
         x as i16 - 11,
         y as i16 + 4,
@@ -223,6 +280,7 @@ fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
     );
 
     draw_text(
+        engine,
         layer,
         x as i16 - 10,
         y as i16 + 6,
@@ -230,6 +288,7 @@ fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
     );
 
     draw_text(
+        engine,
         layer,
         x as i16 - 2,
         y as i16 + 5,
@@ -237,6 +296,7 @@ fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
     );
     // 1.
     draw_text(
+        engine,
         layer,
         x as i16,
         y as i16 + 6,
@@ -244,6 +304,7 @@ fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
     );
     // 2.
     draw_text(
+        engine,
         layer,
         x as i16 + 2,
         y as i16 + 6,
@@ -251,13 +312,15 @@ fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
     );
     // 3.
     draw_text(
+        engine,
         layer,
         x as i16 + 4,
         y as i16 + 6,
         RichText::new("▀").with_fg(Color::RED).with_bg(Color::GREEN),
+        // 4.
     );
-    // 4.
     draw_text(
+        engine,
         layer,
         x as i16 + 6,
         y as i16 + 6,
@@ -267,13 +330,17 @@ fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
     );
     // 5.
     draw_text(
+        engine,
         layer,
         x as i16 + 8,
         y as i16 + 6,
-        RichText::new("▀").with_fg(Color::RED).with_bg(Color::LIGHT_GRAY),
+        RichText::new("▀")
+            .with_fg(Color::RED)
+            .with_bg(Color::LIGHT_GRAY),
     );
     // 6.
     draw_text(
+        engine,
         layer,
         x as i16 + 10,
         y as i16 + 6,
@@ -283,9 +350,12 @@ fn draw_test_case(layer: &mut Layer, x: f32, y: f32) {
     );
     // 7.
     draw_text(
+        engine,
         layer,
         x as i16 + 12,
         y as i16 + 6,
-        RichText::new("▄").with_fg(Color::LIGHT_GRAY).with_bg(Color::RED),
+        RichText::new("▄")
+            .with_fg(Color::LIGHT_GRAY)
+            .with_bg(Color::RED),
     );
 }

--- a/germterm/README.md
+++ b/germterm/README.md
@@ -31,23 +31,24 @@ It renders in real time, adds support for the alpha channel, adds multiple drawi
 ## Getting started
 
 Add `germterm` as a dependency:
-```plain_text,no_run
+
+```plain_text,ignore
 cargo add germterm
 ```
 
-```rust,no_run
+```rust,ignore
 use germterm::{
-    color::Color,
     crossterm::event::{Event, KeyCode, KeyEvent},
-    draw::{Layer, draw_text, fill_screen, draw_fps_counter},
+    draw::{draw_fps_counter, draw_text},
     engine::{Engine, end_frame, exit_cleanup, init, start_frame},
     input::poll_input,
+    layer::create_layer,
 };
 use std::io;
 
 fn main() -> io::Result<()> {
     let mut engine = Engine::new(40, 20);
-    let mut layer = Layer::new(&mut engine, 0);
+    let layer = create_layer(&mut engine, 0);
 
     // Initialize engine and layers
     init(&mut engine)?;
@@ -68,8 +69,8 @@ fn main() -> io::Result<()> {
         }
 
         // Draw contents
-        draw_text(&mut layer, 14, 9, "Hello world!");
-        draw_fps_counter(&mut layer, 0, 0);
+        draw_text(&mut engine, layer, 14, 9, "Hello, Ferris!");
+        draw_fps_counter(&mut engine, layer, 0, 0);
 
         // End the frame
         end_frame(&mut engine)?;

--- a/germterm/src/draw.rs
+++ b/germterm/src/draw.rs
@@ -8,14 +8,9 @@
 //!
 //! ## Layers
 //!
-//! A [`Layer`] is a lightweight handle identifying
-//! a specific draw layer within an [`Engine`].
-//!
-//! Multiple layers may coexist and be drawn independently.
-//!
-//! Layers are sorted during rendering by their specified index, where index 1 would be drawn above index 0, etc.
-//!
-//! You can define as many layers as you need to, they are fairly cheap.
+//! Each drawing function accepts a layer index, created by `layer::create_layer()`.
+//! Layers are ordered and rendered by index and sorted from lowest to highest.
+//! You can define as many layers as you need, they are fairly cheap.
 //!
 //! ## Coordinate space
 //!
@@ -37,7 +32,13 @@
 //! that are consumed by the engine at the end of the frame.
 
 use crate::{
-    color::Color, engine::Engine, fps_counter::get_fps, frame::DrawCall, rich_text::RichText,
+    cell::CellFormat,
+    color::Color,
+    engine::Engine,
+    fps_counter::get_fps,
+    frame::DrawCall,
+    layer::LayerIndex,
+    rich_text::{Attributes, RichText},
 };
 
 #[rustfmt::skip]
@@ -60,106 +61,101 @@ pub(crate) static BLOCKTAD_CHAR_LUT: [char; 256] = [
     '▄', '𜷛', '𜷜', '𜷝', '𜷞', '▙', '𜷟', '𜷠', '𜷡', '𜷢', '▟', '𜷣', '▆', '𜷤', '𜷥', '█',
 ];
 
-/// A handle to a drawing layer.
+/// Draws text at the given coordinates.
 ///
-/// Passed into drawing functions, specifies to which layer the contents will be drawn.
-///
-/// Multiple layers can coexist and be passed around freely.
-///
-/// # Notes
-/// Layer index can not be negative, the lowest layer index is 0.
-///
-/// # SAFETY
-/// A [`Layer`] must not outlive the [`Engine`] it references due to the `&mut Engine` pointer.
-#[derive(Clone, Copy)]
-pub struct Layer {
-    pub(crate) engine_ptr: *mut Engine,
-    pub(crate) index: usize,
-}
-
-impl Layer {
-    /// Creates a drawing layer handle.
-    ///
-    /// # Examples
-    /// ```rust,no_run
-    /// # use germterm::{draw::Layer, engine::Engine};
-    /// let mut engine = Engine::new(40, 20);
-    /// let mut layer = Layer::new(&mut engine, 0);
-    /// ```
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn new(engine_ptr: *mut Engine, layer_index: usize) -> Self {
-        let engine: &mut Engine = unsafe { &mut *engine_ptr };
-        engine.max_layer_index = engine.max_layer_index.max(layer_index);
-
-        Self {
-            engine_ptr,
-            index: layer_index,
-        }
-    }
-}
-
-/// Draws text at the given coordinates on a layer.
-///
-/// Accepts either a `&str` or `String`, which are converted into [`RichText`].
+/// Accepts either a `&str` or `String` or `RichText`.
 ///
 /// # Example
 /// ```rust,no_run
-/// # use germterm::{draw::{Layer, draw_text}, engine::Engine};
+/// # use germterm::{draw::draw_text, layer::create_layer, engine::Engine};
 /// let mut engine = Engine::new(40, 20);
-/// let mut layer = Layer::new(&mut engine, 0);
-/// draw_text(&mut layer, 2, 1, "Hello world!");
+/// let layer = create_layer(&mut engine, 0);
+/// draw_text(&mut engine, layer, 2, 1, "Hello world!");
 /// ```
-pub fn draw_text(layer: &mut Layer, x: i16, y: i16, text: impl Into<RichText>) {
-    let engine: &mut Engine = unsafe { &mut *layer.engine_ptr };
-    let draw_queue: &mut Vec<DrawCall> = &mut engine.frame.layered_draw_queue[layer.index];
-    internal::draw_text(draw_queue, x, y, text);
+pub fn draw_text(
+    engine: &mut Engine,
+    layer_index: LayerIndex,
+    x: i16,
+    y: i16,
+    text: impl Into<RichText>,
+) {
+    let layer = &mut engine.frame.layered_draw_queue[layer_index.0];
+    let rich_text: RichText = text.into();
+
+    layer.0.push(DrawCall { rich_text, x, y });
 }
 
 /// Fills the entire screen with the specified [`Color`].
 ///
 /// # Example
 /// ```rust,no_run
-/// # use germterm::{draw::{Layer, fill_screen}, engine::Engine, color::Color};
+/// # use germterm::{draw::fill_screen, layer::create_layer, engine::Engine, color::Color};
 /// let mut engine = Engine::new(40, 20);
-/// let mut layer = Layer::new(&mut engine, 0);
-/// fill_screen(&mut layer, Color::PINK);
+/// let layer = create_layer(&mut engine, 0);
+/// fill_screen(&mut engine, layer, Color::PINK);
 /// ```
-pub fn fill_screen(layer: &mut Layer, color: Color) {
-    let engine: &mut Engine = unsafe { &mut *layer.engine_ptr };
-    let draw_queue: &mut Vec<DrawCall> = &mut engine.frame.layered_draw_queue[layer.index];
+pub fn fill_screen(engine: &mut Engine, layer_index: LayerIndex, color: Color) {
     let width: i16 = engine.frame.width as i16;
     let height: i16 = engine.frame.height as i16;
-    internal::fill_screen(draw_queue, width, height, color);
+
+    draw_rect(engine, layer_index, 0, 0, height, width, color);
 }
 
 /// Erases a rect area, restoring the default bg color and deleting the characters.
 ///
 /// # Example
 /// ```rust,no_run
-/// # use germterm::{draw::{Layer, erase_rect}, engine::Engine};
+/// # use germterm::{draw::erase_rect, layer::create_layer, engine::Engine};
 /// let mut engine = Engine::new(40, 20);
-/// let mut layer = Layer::new(&mut engine, 0);
-/// erase_rect(&mut layer, 2, 2, 6, 3);
+/// let layer = create_layer(&mut engine, 0);
+/// erase_rect(&mut engine, layer, 2, 2, 6, 3);
 /// ```
-pub fn erase_rect(layer: &mut Layer, x: i16, y: i16, width: i16, height: i16) {
-    let engine: &mut Engine = unsafe { &mut *layer.engine_ptr };
-    let draw_queue: &mut Vec<DrawCall> = &mut engine.frame.layered_draw_queue[layer.index];
-    internal::erase_rect(draw_queue, x, y, width, height)
+pub fn erase_rect(
+    engine: &mut Engine,
+    layer_index: LayerIndex,
+    x: i16,
+    y: i16,
+    width: i16,
+    height: i16,
+) {
+    let row_text: String = " ".repeat(width as usize);
+    let row_rich_text = RichText::new(row_text)
+        .with_fg(Color::CLEAR)
+        .with_bg(Color::CLEAR)
+        .with_attributes(Attributes::NO_FG_COLOR | Attributes::NO_BG_COLOR);
+
+    for row in 0..height {
+        draw_text(engine, layer_index, x, y + row, row_rich_text.clone())
+    }
 }
 
 /// Draws a filled rect area with the specified [`Color`].
 ///
 /// # Example
 /// ```rust,no_run
-/// # use germterm::{draw::{Layer, draw_rect}, engine::Engine, color::Color};
+/// # use germterm::{draw::draw_rect, layer::create_layer, engine::Engine, color::Color};
 /// let mut engine = Engine::new(40, 20);
-/// let mut layer = Layer::new(&mut engine, 0);
-/// draw_rect(&mut layer, 10, 5, 20, 10, Color::CYAN);
+/// let layer = create_layer(&mut engine, 0);
+/// draw_rect(&mut engine, layer, 10, 5, 20, 10, Color::CYAN);
 /// ```
-pub fn draw_rect(layer: &mut Layer, x: i16, y: i16, width: i16, height: i16, color: Color) {
-    let engine: &mut Engine = unsafe { &mut *layer.engine_ptr };
-    let draw_queue: &mut Vec<DrawCall> = &mut engine.frame.layered_draw_queue[layer.index];
-    internal::draw_rect(draw_queue, x, y, width, height, color);
+pub fn draw_rect(
+    engine: &mut Engine,
+    layer_index: LayerIndex,
+    x: i16,
+    y: i16,
+    width: i16,
+    height: i16,
+    color: Color,
+) {
+    let row_text: String = " ".repeat(width as usize);
+    let row_rich_text: RichText = RichText::new(&row_text)
+        .with_fg(Color::CLEAR)
+        .with_bg(color)
+        .with_attributes(Attributes::NO_FG_COLOR);
+
+    for row in 0..height {
+        draw_text(engine, layer_index, x, y + row, row_rich_text.clone())
+    }
 }
 
 /// Draws a single octad at the specified sub-cell position.
@@ -177,19 +173,40 @@ pub fn draw_rect(layer: &mut Layer, x: i16, y: i16, width: i16, height: i16, col
 ///
 /// # Example
 /// ```rust,no_run
-/// # use germterm::{draw::{Layer, draw_octad}, engine::Engine, color::Color};
+/// # use germterm::{draw::draw_octad, layer::create_layer, engine::Engine, color::Color};
 /// let mut engine = Engine::new(40, 20);
-/// let mut layer = Layer::new(&mut engine, 0);
+/// let layer = create_layer(&mut engine, 0);
 ///
 /// // The following octads would occupy the same cell,
 /// // resulting in a merged octad cluster being drawn
-/// draw_octad(&mut layer, 3.0, 4.0, Color::YELLOW);
-/// draw_octad(&mut layer, 3.0, 4.5, Color::YELLOW);
+/// draw_octad(&mut engine, layer, 3.0, 4.0, Color::YELLOW);
+/// draw_octad(&mut engine, layer, 3.0, 4.5, Color::YELLOW);
 /// ```
-pub fn draw_octad(layer: &mut Layer, x: f32, y: f32, color: Color) {
-    let engine: &mut Engine = unsafe { &mut *layer.engine_ptr };
-    let draw_queue: &mut Vec<DrawCall> = &mut engine.frame.layered_draw_queue[layer.index];
-    internal::draw_octad(draw_queue, x, y, color);
+pub fn draw_octad(engine: &mut Engine, layer_index: LayerIndex, x: f32, y: f32, color: Color) {
+    let cell_x: i16 = x.floor() as i16;
+    let cell_y: i16 = y.floor() as i16;
+
+    let sub_x: u8 = ((x - cell_x as f32) * 2.0).clamp(0.0, 1.0) as u8;
+    let sub_y_float: f32 = (y - cell_y as f32) * 4.0;
+    let sub_y: usize = sub_y_float.floor().clamp(0.0, 3.0) as usize;
+    let offset: usize = match (sub_x, sub_y) {
+        (0, 0) => 0,
+        (0, 1) => 1,
+        (0, 2) => 2,
+        (0, 3) => 6,
+        (1, 0) => 3,
+        (1, 1) => 4,
+        (1, 2) => 5,
+        (1, 3) => 7,
+        _ => panic!("Octad sub-position ({sub_x}, {sub_y}) falls out of range."),
+    };
+
+    let braille_char: char = std::char::from_u32(0x2800 + (1 << offset)).unwrap();
+    let rich_text: RichText = RichText::new(braille_char.to_string())
+        .with_fg(color)
+        .with_cell_format(CellFormat::Octad);
+
+    draw_text(engine, layer_index, cell_x, cell_y, rich_text);
 }
 
 /// Draws a single blocktad at the specified sub-cell position.
@@ -207,23 +224,34 @@ pub fn draw_octad(layer: &mut Layer, x: f32, y: f32, color: Color) {
 ///
 /// # Example
 /// ```rust,no_run
-/// # use germterm::{draw::{Layer, draw_blocktad}, engine::Engine, color::Color};
+/// # use germterm::{draw::draw_blocktad, layer::create_layer, engine::Engine, color::Color};
 /// let mut engine = Engine::new(40, 20);
-/// let mut layer = Layer::new(&mut engine, 0);
+/// let layer = create_layer(&mut engine, 0);
 ///
 /// // The following blocktads would occupy the same cell,
 /// // resulting in a merged blocktad cluster being drawn
-/// draw_blocktad(&mut layer, 3.0, 4.0, Color::GREEN);
-/// draw_blocktad(&mut layer, 3.0, 4.5, Color::GREEN);
+/// draw_blocktad(&mut engine, layer, 3.0, 4.0, Color::GREEN);
+/// draw_blocktad(&mut engine, layer, 3.0, 4.5, Color::GREEN);
 /// ```
 ///
 /// /// # Notes
 /// The characters may not show up on all fonts, as the [Symbols for Legacy Computing Supplement](https://en.wikipedia.org/wiki/Symbols_for_Legacy_Computing_Supplement)
 /// Unicode block is a relatively recent addition. Use with caution.
-pub fn draw_blocktad(layer: &mut Layer, x: f32, y: f32, color: Color) {
-    let engine: &mut Engine = unsafe { &mut *layer.engine_ptr };
-    let draw_queue: &mut Vec<DrawCall> = &mut engine.frame.layered_draw_queue[layer.index];
-    internal::draw_blocktad(draw_queue, x, y, color);
+pub fn draw_blocktad(engine: &mut Engine, layer_index: LayerIndex, x: f32, y: f32, color: Color) {
+    let cell_x: i16 = x.floor() as i16;
+    let cell_y: i16 = y.floor() as i16;
+
+    let sub_x: usize = (((x - cell_x as f32) * 2.0).floor().clamp(0.0, 1.0)) as usize;
+    let sub_y: usize = (((y - cell_y as f32) * 4.0).floor().clamp(0.0, 3.0)) as usize;
+    let offset: usize = sub_y * 2 + sub_x;
+    let mask: usize = 1 << offset;
+
+    let blocktad_char: char = BLOCKTAD_CHAR_LUT[mask];
+    let rich_text: RichText = RichText::new(blocktad_char.to_string())
+        .with_fg(color)
+        .with_cell_format(CellFormat::Blocktad);
+
+    draw_text(engine, layer_index, cell_x, cell_y, rich_text);
 }
 
 /// Draws a single twoxel at the specified sub-cell position.
@@ -241,19 +269,32 @@ pub fn draw_blocktad(layer: &mut Layer, x: f32, y: f32, color: Color) {
 ///
 /// # Example
 /// ```rust,no_run
-/// # use germterm::{draw::{Layer, draw_twoxel}, engine::Engine, color::Color};
+/// # use germterm::{draw::draw_twoxel, layer::create_layer, engine::Engine, color::Color};
 /// let mut engine = Engine::new(40, 20);
-/// let mut layer = Layer::new(&mut engine, 0);
+/// let layer = create_layer(&mut engine, 0);
 ///
 /// // The following twoxels would occupy the same cell,
 /// // resulting in a merged twoxel with independent colors
-/// draw_twoxel(&mut layer, 3.0, 4.0, Color::RED);
-/// draw_twoxel(&mut layer, 3.0, 4.5, Color::CYAN);
+/// draw_twoxel(&mut engine, layer, 3.0, 4.0, Color::RED);
+/// draw_twoxel(&mut engine, layer, 3.0, 4.5, Color::CYAN);
 /// ```
-pub fn draw_twoxel(layer: &mut Layer, x: f32, y: f32, color: Color) {
-    let engine: &mut Engine = unsafe { &mut *layer.engine_ptr };
-    let draw_queue: &mut Vec<DrawCall> = &mut engine.frame.layered_draw_queue[layer.index];
-    internal::draw_twoxel(draw_queue, x, y, color);
+pub fn draw_twoxel(engine: &mut Engine, layer_index: LayerIndex, x: f32, y: f32, color: Color) {
+    let cell_x: i16 = x.floor() as i16;
+    let cell_y: i16 = y.floor() as i16;
+
+    let sub_y_float: f32 = (y - cell_y as f32) * 2.0;
+    let sub_y: usize = sub_y_float.floor().clamp(0.0, 1.0) as usize;
+
+    let half_block: char = match sub_y {
+        0 => '▀',
+        1 => '▄',
+        _ => panic!("Twoxel 'sub_y': {sub_y} falls out of range."),
+    };
+    let rich_text: RichText = RichText::new(half_block.to_string())
+        .with_fg(color)
+        .with_cell_format(CellFormat::Twoxel);
+
+    draw_text(engine, layer_index, cell_x, cell_y, rich_text)
 }
 
 /// Draws the current FPS.
@@ -265,131 +306,12 @@ pub fn draw_twoxel(layer: &mut Layer, x: f32, y: f32, color: Color) {
 ///
 /// # Example
 /// ```rust,no_run
-/// # use germterm::{draw::{Layer, draw_fps_counter}, engine::Engine};
+/// # use germterm::{draw::draw_fps_counter, layer::create_layer, engine::Engine};
 /// let mut engine = Engine::new(40, 20);
-/// let mut layer = Layer::new(&mut engine, 0);
-/// draw_fps_counter(&mut layer, 0, 0);
+/// let layer = create_layer(&mut engine, 0);
+/// draw_fps_counter(&mut engine, layer, 0, 0);
 /// ```
-pub fn draw_fps_counter(layer: &mut Layer, x: i16, y: i16) {
-    let engine: &mut Engine = unsafe { &mut *layer.engine_ptr };
-    draw_text(layer, x, y, format!("FPS: {:2.0}", get_fps(engine)));
-}
-
-pub(crate) mod internal {
-    use crate::{
-        cell::CellFormat,
-        color::Color,
-        draw::BLOCKTAD_CHAR_LUT,
-        frame::DrawCall,
-        rich_text::{Attributes, RichText},
-    };
-
-    pub fn fill_screen(draw_queue: &mut Vec<DrawCall>, cols: i16, rows: i16, color: Color) {
-        draw_rect(draw_queue, 0, 0, cols, rows, color);
-    }
-
-    pub fn draw_text(draw_queue: &mut Vec<DrawCall>, x: i16, y: i16, text: impl Into<RichText>) {
-        let rich_text: RichText = text.into();
-        draw_queue.push(DrawCall { rich_text, x, y });
-    }
-
-    pub fn draw_rect(
-        draw_queue: &mut Vec<DrawCall>,
-        x: i16,
-        y: i16,
-        width: i16,
-        height: i16,
-        color: Color,
-    ) {
-        let row_text: String = " ".repeat(width as usize);
-        let row_rich_text: RichText = RichText::new(&row_text)
-            .with_fg(Color::CLEAR)
-            .with_bg(color)
-            .with_attributes(Attributes::NO_FG_COLOR);
-
-        for row in 0..height {
-            draw_text(draw_queue, x, y + row, row_rich_text.clone())
-        }
-    }
-
-    pub fn erase_rect(draw_queue: &mut Vec<DrawCall>, x: i16, y: i16, width: i16, height: i16) {
-        let row_text: String = " ".repeat(width as usize);
-        let row_rich_text = RichText::new(row_text)
-            .with_fg(Color::CLEAR)
-            .with_bg(Color::CLEAR)
-            .with_attributes(Attributes::NO_FG_COLOR | Attributes::NO_BG_COLOR);
-
-        for row in 0..height {
-            draw_text(draw_queue, x, y + row, row_rich_text.clone())
-        }
-    }
-
-    pub fn draw_blocktad(draw_queue: &mut Vec<DrawCall>, x: f32, y: f32, color: Color) {
-        let cell_x: i16 = x.floor() as i16;
-        let cell_y: i16 = y.floor() as i16;
-
-        let sub_x: usize = (((x - cell_x as f32) * 2.0).floor().clamp(0.0, 1.0)) as usize;
-        let sub_y: usize = (((y - cell_y as f32) * 4.0).floor().clamp(0.0, 3.0)) as usize;
-
-        let offset: usize = sub_y * 2 + sub_x;
-        let mask: usize = 1 << offset;
-
-        let blocktad_char: char = BLOCKTAD_CHAR_LUT[mask];
-
-        let rich_text: RichText = RichText::new(blocktad_char.to_string())
-            .with_fg(color)
-            .with_cell_format(CellFormat::Blocktad);
-
-        draw_text(draw_queue, cell_x, cell_y, rich_text);
-    }
-
-    pub fn draw_octad(draw_queue: &mut Vec<DrawCall>, x: f32, y: f32, color: Color) {
-        let cell_x: i16 = x.floor() as i16;
-        let cell_y: i16 = y.floor() as i16;
-
-        let sub_x: u8 = ((x - cell_x as f32) * 2.0).clamp(0.0, 1.0) as u8;
-        let sub_y_float: f32 = (y - cell_y as f32) * 4.0;
-        let sub_y: usize = sub_y_float.floor().clamp(0.0, 3.0) as usize;
-
-        let offset: usize = match (sub_x, sub_y) {
-            (0, 0) => 0,
-            (0, 1) => 1,
-            (0, 2) => 2,
-            (0, 3) => 6,
-            (1, 0) => 3,
-            (1, 1) => 4,
-            (1, 2) => 5,
-            (1, 3) => 7,
-            _ => panic!(
-                "Octad sub-position ({sub_x}, {sub_y}) falls out of expected ranges (0..1, 0..3)"
-            ),
-        };
-
-        let braille_char: char = std::char::from_u32(0x2800 + (1 << offset)).unwrap();
-        let rich_text: RichText = RichText::new(braille_char.to_string())
-            .with_fg(color)
-            .with_cell_format(CellFormat::Octad);
-
-        draw_text(draw_queue, cell_x, cell_y, rich_text);
-    }
-
-    pub fn draw_twoxel(draw_queue: &mut Vec<DrawCall>, x: f32, y: f32, color: Color) {
-        let cell_x: i16 = x.floor() as i16;
-        let cell_y: i16 = y.floor() as i16;
-
-        let sub_y_float: f32 = (y - cell_y as f32) * 2.0;
-        let sub_y: usize = sub_y_float.floor().clamp(0.0, 1.0) as usize;
-
-        let half_block: char = match sub_y {
-            0 => '▀',
-            1 => '▄',
-            _ => panic!("Twoxel 'sub_y': {sub_y} falls out of the expected 0..1 range"),
-        };
-
-        let rich_text: RichText = RichText::new(half_block.to_string())
-            .with_fg(color)
-            .with_cell_format(CellFormat::Twoxel);
-
-        draw_text(draw_queue, cell_x, cell_y, rich_text)
-    }
+pub fn draw_fps_counter(engine: &mut Engine, layer_index: LayerIndex, x: i16, y: i16) {
+    let text: String = format!("FPS: {:2.0}", get_fps(engine));
+    draw_text(engine, layer_index, x, y, text);
 }

--- a/germterm/src/engine.rs
+++ b/germterm/src/engine.rs
@@ -6,11 +6,11 @@
 
 use crate::{
     color::{Color, ColorRgb},
-    draw::{Layer, erase_rect},
+    draw::erase_rect,
     fps_counter::{FpsCounter, update_fps_counter},
     fps_limiter::{self, FpsLimiter, wait_for_next_frame},
-    frame::FramePair,
-    frame::{compose_frame_buffer, draw_to_terminal},
+    frame::{FramePair, compose_frame_buffer, draw_to_terminal},
+    layer::{Layer, LayerIndex, create_layer},
     particle::{ParticleState, update_and_draw_particles},
 };
 use crossterm::{cursor, event, execute, terminal};
@@ -73,18 +73,14 @@ pub fn override_default_blending_color(engine: &mut Engine, color: ColorRgb) {
     engine.default_blending_color = color.into();
 }
 
-/// This function should be called once after constructing the [`Engine`] and defining the [`Layer`]s,
+/// This function should be called once after constructing the [`Engine`] and defining layers,
 /// and before entering the main update loop to initialize the engine.
-///
-/// # Panics
-/// This function will not panic directly, but misusing it by defining a [`Layer`] after
-/// [`init`] has been called, and then referencing the layer will likely cause a panic.
 ///
 /// # Example
 /// ```rust,no_run
-/// # use germterm::{draw::{Layer}, engine::{Engine, init}};
+/// # use germterm::{layer::create_layer, engine::{Engine, init}};
 /// let mut engine = Engine::new(40, 20);
-/// let mut layer = Layer::new(&mut engine, 0);
+/// let layer = create_layer(&mut engine, 0);
 /// init(&mut engine);
 /// ```
 pub fn init(engine: &mut Engine) -> io::Result<()> {
@@ -93,7 +89,7 @@ pub fn init(engine: &mut Engine) -> io::Result<()> {
         engine
             .frame
             .layered_draw_queue
-            .resize_with(layer_count, Vec::new);
+            .resize_with(layer_count, Layer::new);
     }
 
     terminal::enable_raw_mode()?;
@@ -132,9 +128,10 @@ pub fn start_frame(engine: &mut Engine) {
     engine.delta_time = wait_for_next_frame(&mut engine.fps_limiter);
     update_fps_counter(&mut engine.fps_counter, engine.delta_time);
 
-    let mut lowest_possible_layer = Layer::new(engine, 0);
+    let lowest_layer_index: LayerIndex = create_layer(engine, 0);
     erase_rect(
-        &mut lowest_possible_layer,
+        engine,
+        lowest_layer_index,
         0,
         0,
         engine.frame.width as i16,
@@ -155,7 +152,7 @@ pub fn end_frame(engine: &mut Engine) -> io::Result<()> {
     let (current, layered) = engine.frame.current_mut_and_layered_mut();
     compose_frame_buffer(
         current,
-        layered.iter_mut().flat_map(|v| v.drain(..)),
+        layered.iter_mut().flat_map(|v| v.0.drain(..)),
         width,
         height,
         engine.default_blending_color,

--- a/germterm/src/frame.rs
+++ b/germterm/src/frame.rs
@@ -2,6 +2,7 @@ use crate::{
     cell::{Cell, CellFormat},
     color::{Color, blend_source_over},
     draw::BLOCKTAD_CHAR_LUT,
+    layer::Layer,
     rich_text::{Attributes, RichText},
 };
 use crossterm::{cursor as ctcursor, queue, style as ctstyle};
@@ -62,7 +63,7 @@ pub struct FramePair {
     order: FrameOrder,
     pub(crate) width: u16,
     pub(crate) height: u16,
-    pub(crate) layered_draw_queue: Vec<Vec<DrawCall>>,
+    pub(crate) layered_draw_queue: Vec<Layer>,
 }
 
 impl FramePair {
@@ -115,7 +116,7 @@ impl FramePair {
         };
     }
 
-    pub fn current_mut_and_layered_mut(&mut self) -> (FrameMut<'_>, &mut Vec<Vec<DrawCall>>) {
+    pub fn current_mut_and_layered_mut(&mut self) -> (FrameMut<'_>, &mut Vec<Layer>) {
         let frame = FrameMut(&mut self.frames, self.order as usize);
         let layers = &mut self.layered_draw_queue;
         (frame, layers)

--- a/germterm/src/layer.rs
+++ b/germterm/src/layer.rs
@@ -1,0 +1,23 @@
+use crate::{engine::Engine, frame::DrawCall};
+
+pub fn create_layer(engine: &mut Engine, index: usize) -> LayerIndex {
+    engine.max_layer_index = engine.max_layer_index.max(index);
+    LayerIndex(index)
+}
+
+#[derive(Copy, Clone)]
+pub struct LayerIndex(pub(crate) usize);
+
+pub struct Layer(pub(crate) Vec<DrawCall>);
+
+impl Layer {
+    pub const fn new() -> Self {
+        Layer(Vec::new())
+    }
+}
+
+impl Default for Layer {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/germterm/src/lib.rs
+++ b/germterm/src/lib.rs
@@ -10,5 +10,6 @@ pub mod fps_counter;
 mod fps_limiter;
 pub mod frame;
 pub mod input;
+pub mod layer;
 pub mod particle;
 pub mod rich_text;


### PR DESCRIPTION
First part of the drawing API redesign, I've decided to start small and only touch layer-specific bits in this PR.

- `Layer` is now reserved for internal use, the new public API uses `LayerIndex` and the `create_layer()` factory
- Changed drawing function first args from `&mut Layer` to `&mut Engine` and `LayerIndex`

In reference to issue #3.