### PR TITLE
make fps_limiter public again

### DIFF
--- a/germterm/src/lib.rs
+++ b/germterm/src/lib.rs
@@ -7,7 +7,7 @@ pub mod color;
 pub mod draw;
 pub mod engine;
 pub mod fps_counter;
-mod fps_limiter;
+pub mod fps_limiter;
 pub mod frame;
 pub mod input;
 pub mod layer;


### PR DESCRIPTION
I don't understand why it would be private unless I'm missing something