### PR TITLE
Support for emoji and symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,9 @@ dependencies = [
  "criterion",
  "crossterm 0.29.0",
  "rand",
+ "sinstr",
  "termbg",
+ "unicode-segmentation",
  "unicode-width",
 ]
 
@@ -889,6 +891,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sinstr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c383ea82ae0eaeca14e3b0cb85fcae80501591b98be989a32e1d8a3f1b9265d"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,9 +1036,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
 
 [[package]]
 name = "unicode-width"

--- a/germterm/Cargo.toml
+++ b/germterm/Cargo.toml
@@ -12,7 +12,9 @@ authors.workspace = true
 bitflags = "2.10.0"
 crossterm = "0.29.0"
 rand = "0.9.2"
+sinstr = "0.4.0"
 termbg = "0.6.2"
+unicode-segmentation = "1.13.1"
 unicode-width = "0.2.2"
 
 [dev-dependencies]

--- a/germterm/Cargo.toml
+++ b/germterm/Cargo.toml
@@ -23,3 +23,7 @@ criterion = "0.5"
 [[bench]]
 name = "frame"
 harness = false
+
+[[bench]]
+name = "gfx"
+harness = false

--- a/germterm/benches/frame.rs
+++ b/germterm/benches/frame.rs
@@ -6,18 +6,19 @@ use germterm::{
         buffer::{Buffer, Drawer, paired::PairedBuffer},
         draw::{Position, Size},
     },
+    style::{Attributes, Style},
 };
 
 fn full_cell() -> Cell {
-    let mut cell = Cell::EMPTY;
-    cell.ch = 'X';
-    cell.fg = Color::WHITE;
-    cell.bg = Color::BLACK;
-    cell
+    Cell::new(
+        "X",
+        Style::new(Color::WHITE, Color::BLACK, Attributes::empty()),
+    )
 }
 
 fn bench_frame_diff(c: &mut Criterion) {
     let mut group = c.benchmark_group("Frame Diff");
+    let fc = full_cell();
 
     // Dimensions to test
     let dimensions = vec![
@@ -48,7 +49,7 @@ fn bench_frame_diff(c: &mut Criterion) {
 
                 for y in 0..sz.height {
                     for x in 0..sz.width {
-                        buf.set_cell(Position::new(x, y), full_cell());
+                        buf.set_cell(Position::new(x, y), &fc);
                     }
                 }
 
@@ -70,7 +71,7 @@ fn bench_frame_diff(c: &mut Criterion) {
                 for y in 0..sz.height {
                     for x in 0..sz.width {
                         if x * y % 2 == 0 {
-                            buf.set_cell(Position::new(x, y), full_cell());
+                            buf.set_cell(Position::new(x, y), &fc);
                         }
                     }
                 }

--- a/germterm/benches/gfx.rs
+++ b/germterm/benches/gfx.rs
@@ -1,0 +1,378 @@
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use germterm::{
+    cell::Cell,
+    color::Color,
+    core::{
+        DisplayWidth,
+        buffer::flat::FlatBuffer,
+        draw::gfx::normal,
+        draw::gfx::text,
+        draw::{Position, Rect, Size},
+        widget::FrameContext,
+    },
+    style::{Attributes, Style},
+};
+
+fn test_cell() -> Cell {
+    Cell::new(
+        "#",
+        Style::new(Color::WHITE, Color::BLACK, Attributes::empty()),
+    )
+}
+
+fn make_fc(buf: &mut FlatBuffer) -> FrameContext<'_, FlatBuffer, f32> {
+    FrameContext::new(0.0, 0.0, buf, DisplayWidth::default())
+}
+
+fn bench_vline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("draw_vline");
+    let cell = test_cell();
+    let dimensions = [(80, 24), (120, 40), (1920, 1080)];
+
+    for (width, height) in dimensions {
+        let sz = Size::new(width, height);
+
+        group.bench_with_input(
+            BenchmarkId::new("short", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                b.iter(|| {
+                    normal::draw_vline(&mut buf, Position::ZERO, 10, black_box(&cell));
+                    black_box(&mut buf);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("medium", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let len = height / 2;
+                b.iter(|| {
+                    normal::draw_vline(&mut buf, Position::ZERO, len, black_box(&cell));
+                    black_box(&mut buf);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("full_height", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                b.iter(|| {
+                    normal::draw_vline(&mut buf, Position::ZERO, height, black_box(&cell));
+                    black_box(&mut buf);
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_hline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("draw_hline");
+    let cell = test_cell();
+    let dimensions = [(80, 24), (120, 40), (1920, 1080)];
+
+    for (width, height) in dimensions {
+        let sz = Size::new(width, height);
+
+        group.bench_with_input(
+            BenchmarkId::new("short", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                b.iter(|| {
+                    normal::draw_hline(&mut buf, Position::ZERO, 10, black_box(&cell));
+                    black_box(&mut buf);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("medium", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let len = width / 2;
+                b.iter(|| {
+                    normal::draw_hline(&mut buf, Position::ZERO, len, black_box(&cell));
+                    black_box(&mut buf);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("full_width", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                b.iter(|| {
+                    normal::draw_hline(&mut buf, Position::ZERO, width, black_box(&cell));
+                    black_box(&mut buf);
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_line(c: &mut Criterion) {
+    let mut group = c.benchmark_group("draw_line");
+    let cell = test_cell();
+    let dimensions = [(80, 24), (120, 40), (1920, 1080)];
+
+    for (width, height) in dimensions {
+        let sz = Size::new(width, height);
+
+        group.bench_with_input(
+            BenchmarkId::new("diagonal", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let start = Position::new(0, 0);
+                let end = Position::new(width - 1, height - 1);
+                b.iter(|| {
+                    normal::draw_line(&mut buf, start, end, black_box(&cell));
+                    black_box(&mut buf);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("horizontal", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let start = Position::new(0, 0);
+                let end = Position::new(width - 1, 0);
+                b.iter(|| {
+                    normal::draw_line(&mut buf, start, end, black_box(&cell));
+                    black_box(&mut buf);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("vertical", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let start = Position::new(0, 0);
+                let end = Position::new(0, height - 1);
+                b.iter(|| {
+                    normal::draw_line(&mut buf, start, end, black_box(&cell));
+                    black_box(&mut buf);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("steep_diagonal", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let start = Position::new(0, 0);
+                let end = Position::new(width / 4, height - 1);
+                b.iter(|| {
+                    normal::draw_line(&mut buf, start, end, black_box(&cell));
+                    black_box(&mut buf);
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_style(c: &mut Criterion) {
+    let mut group = c.benchmark_group("draw_style");
+    let style = Style::new(Color::RED, Color::BLUE, Attributes::BOLD);
+    let dimensions = [(80, 24), (120, 40), (1920, 1080)];
+
+    for (width, height) in dimensions {
+        let sz = Size::new(width, height);
+
+        group.bench_with_input(
+            BenchmarkId::new("full_area", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let rect = Rect::new(Position::ZERO, sz);
+                b.iter(|| {
+                    normal::draw_style(&mut buf, rect, style);
+                    black_box(&mut buf);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("partial_area", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let rect = Rect::new(
+                    Position::new(width / 4, height / 4),
+                    Size::new(width / 2, height / 2),
+                );
+                b.iter(|| {
+                    normal::draw_style(&mut buf, rect, style);
+                    black_box(&mut buf);
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_draw_string(c: &mut Criterion) {
+    let mut group = c.benchmark_group("draw_string");
+    let dimensions = [(80, 24), (120, 40), (1920, 1080)];
+
+    for (width, height) in dimensions {
+        let sz = Size::new(width, height);
+
+        group.bench_with_input(
+            BenchmarkId::new("ascii_short", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                b.iter(|| {
+                    let fc = make_fc(&mut buf);
+                    text::draw_string(fc, Position::ZERO, "hello world");
+                    black_box(&mut buf);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("ascii_medium", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let text = "The quick brown fox jumps over the lazy dog";
+                b.iter(|| {
+                    let fc = make_fc(&mut buf);
+                    text::draw_string(fc, Position::ZERO, text);
+                    black_box(&mut buf);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("emoji", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let text = "😀😎🎉🚀💡";
+                b.iter(|| {
+                    let fc = make_fc(&mut buf);
+                    text::draw_string(fc, Position::ZERO, text);
+                    black_box(&mut buf);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("cjk", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let text = "中日韩文字测试";
+                b.iter(|| {
+                    let fc = make_fc(&mut buf);
+                    text::draw_string(fc, Position::ZERO, text);
+                    black_box(&mut buf);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("mixed_unicode", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let text = "Hello 世界! 🌍 Test 中文 mixed 😀";
+                b.iter(|| {
+                    let fc = make_fc(&mut buf);
+                    text::draw_string(fc, Position::ZERO, text);
+                    black_box(&mut buf);
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_draw_text(c: &mut Criterion) {
+    let mut group = c.benchmark_group("draw_text");
+    let style = Style::new(Color::GREEN, Color::BLACK, Attributes::UNDERLINED);
+    let dimensions = [(80, 24), (120, 40), (1920, 1080)];
+
+    for (width, height) in dimensions {
+        let sz = Size::new(width, height);
+
+        group.bench_with_input(
+            BenchmarkId::new("ascii_styled", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let text = "styled text example";
+                b.iter(|| {
+                    let fc = make_fc(&mut buf);
+                    text::draw_text(fc, Position::ZERO, text, style, u16::MAX);
+                    black_box(&mut buf);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("unicode_styled", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let text = "Styled 世界 🎨";
+                b.iter(|| {
+                    let fc = make_fc(&mut buf);
+                    text::draw_text(fc, Position::ZERO, text, style, u16::MAX);
+                    black_box(&mut buf);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("long_text_limited", format!("{}x{}", width, height)),
+            &sz,
+            |b, &sz| {
+                let mut buf = FlatBuffer::new(sz);
+                let text =
+                    "This is a much longer piece of text that would normally exceed buffer width";
+                b.iter(|| {
+                    let fc = make_fc(&mut buf);
+                    text::draw_text(fc, Position::ZERO, text, style, width);
+                    black_box(&mut buf);
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_vline,
+    bench_hline,
+    bench_line,
+    bench_style,
+    bench_draw_string,
+    bench_draw_text,
+);
+criterion_main!(benches);

--- a/germterm/src/cell.rs
+++ b/germterm/src/cell.rs
@@ -1,3 +1,5 @@
+use sinstr::{SinStr, sinstr_literal};
+
 use crate::style::Style;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -8,22 +10,48 @@ pub enum CellFormat {
     Blocktad,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Cell {
-    pub ch: char,
-    pub style: Style,
-    pub format: CellFormat,
+    ch: SinStr,
+    style: Style,
+    format: CellFormat,
 }
 
 impl Cell {
     pub const EMPTY: Cell = Cell {
-        ch: ' ',
+        ch: sinstr_literal!(" "),
         style: Style::EMPTY,
         format: CellFormat::Standard,
     };
 
-    pub fn merge(&mut self, other: Self) {
-        self.ch = other.ch;
+    pub fn new(s: &str, style: Style) -> Self {
+        Self {
+            ch: SinStr::new(s),
+            style,
+            format: CellFormat::Standard,
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.ch.as_str()
+    }
+
+    pub fn style(&self) -> Style {
+        self.style
+    }
+
+    pub fn style_mut(&mut self) -> &mut Style {
+        &mut self.style
+    }
+
+    pub fn set_str(&mut self, s: &str) {
+        self.ch.set_str(s);
+    }
+
+    pub fn merge(&mut self, other: &Self) {
+        // We can use `SinStr::clone_from` here which is faster than
+        // `SinStr::set_str`
+        self.ch.clone_from(&other.ch);
         self.style.merge(other.style);
     }
 }

--- a/germterm/src/core/buffer/builder/mod.rs
+++ b/germterm/src/core/buffer/builder/mod.rs
@@ -3,7 +3,7 @@ pub mod row;
 use crate::{
     cell::Cell,
     core::{
-        buffer::{builder::row::BuilderRow, Buffer},
+        buffer::{Buffer, builder::row::BuilderRow, flat::FlatBuffer},
         draw::{Position, Size},
     },
 };
@@ -16,13 +16,15 @@ pub struct BuilderBuffer {
 
 #[allow(unused)]
 impl BuilderBuffer {
-    const fn new(items: &'static [BuilderBufferItem]) -> Self {
+    #[doc(hidden)]
+    pub const fn new(items: &'static [BuilderBufferItem]) -> Self {
         Self {
             rows: items,
             size: Self::size(items),
         }
     }
 
+    #[doc(hidden)]
     const fn size(items: &'static [BuilderBufferItem]) -> Size {
         let width = Self::width(items);
         let height = Self::height(items);
@@ -30,6 +32,7 @@ impl BuilderBuffer {
         Size::new(width, height)
     }
 
+    #[doc(hidden)]
     const fn height(items: &'static [BuilderBufferItem]) -> u16 {
         let mut i = 0;
         let mut height = 0;
@@ -125,38 +128,21 @@ macro_rules! builder_buffer_internal  {
 #[macro_export]
 macro_rules! builder_buffer{
     ($($tokens:tt)+) => {{
-        #[allow(unused)]
-        use $crate::{
-            core::buffer::builder::{
-                BuilderBuffer as BB, BuilderBufferItem as BBI,
-                row::{
-                    BuilderRowItem as BRI,
-                    BuilderRowItem::{Cell as cell, Empty as empty},
-                },
-            },
-            style::Style as ST,
-        };
-
         const BUILT_BUFFER: BB = const { $crate::builder_buffer_internal!{@munched[] $($tokens)+} };
 
         BUILT_BUFFER
     }};
 }
 
-/// Renders a [`BuilderBuffer`] into a [`Buffer`].
-///
-/// # Panics
-///
-/// Panics if the buffer layout exceeds the target buffer bounds.
-///
-/// # Examples
-///
-/// ```
-/// let mut fb = FlatBuffer::new(layout.size);
-/// build(&layout, &mut fb);
-/// ```
 #[doc(hidden)]
-pub fn build(bb: &BuilderBuffer, buf: &mut dyn Buffer) {
+pub fn build_buffer(bb: &BuilderBuffer) -> impl Buffer {
+    let mut fb = FlatBuffer::new(bb.size);
+    build_any_buffer(bb, &mut fb);
+    fb
+}
+
+#[doc(hidden)]
+pub fn build_any_buffer(bb: &BuilderBuffer, buf: &mut dyn Buffer) {
     let mut cursor = Position::ZERO;
     let sz = buf.size();
     bb.rows.iter().for_each(|row| match row {
@@ -228,14 +214,30 @@ pub fn build(bb: &BuilderBuffer, buf: &mut dyn Buffer) {
 /// ```
 #[macro_export]
 macro_rules! buffer {
-    ($($buffer_contents:tt)*) => {
-        $crate::builder_buffer!{$($buffer_contents)*}
-    };
+    ($($buffer_contents:tt)*) => {{
+        #[allow(unused)]
+        use $crate::{
+            core::buffer::builder::{
+                BuilderBuffer as BB, BuilderBufferItem as BBI,
+                row::{
+                    BuilderRowItem as BRI,
+                    BuilderRowItem::{Cell as cell, Empty as empty},
+                },
+                build_buffer,
+            },
+            style::Style as ST,
+            builder_buffer,
+        };
+
+        const BC: BB = builder_buffer!{$($buffer_contents)*};
+
+        build_buffer(&BC)
+    }};
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::core::buffer::{builder::BuilderBuffer, flat::FlatBuffer, Buffer};
+    use crate::core::buffer::Buffer;
     use crate::core::draw::Position;
     use crate::style::Style;
 
@@ -243,7 +245,7 @@ mod tests {
     fn simple() {
         use crate::cell::Cell;
 
-        const MY_BUFFER: BuilderBuffer = builder_buffer!(
+        let buf = buffer!(
             ["a", "b", empty(1)],
             empty(3),
             [empty(1), "b", cell("c", Style::EMPTY)],
@@ -254,20 +256,17 @@ mod tests {
             ["a5", "b", "c"]
         );
 
-        let mut fb = FlatBuffer::new(MY_BUFFER.size);
-        super::build(&MY_BUFFER, &mut fb);
+        assert_eq!(buf.get_cell(Position::new(0, 0)).as_str(), "a");
+        assert_eq!(buf.get_cell(Position::new(1, 0)).as_str(), "b");
+        assert_eq!(buf.get_cell(Position::new(2, 0)), &Cell::EMPTY);
 
-        assert_eq!(fb.get_cell(Position::new(0, 0)).as_str(), "a");
-        assert_eq!(fb.get_cell(Position::new(1, 0)).as_str(), "b");
-        assert_eq!(fb.get_cell(Position::new(2, 0)), &Cell::EMPTY);
+        assert_eq!(buf.get_cell(Position::new(1, 4)).as_str(), "b");
+        assert_eq!(buf.get_cell(Position::new(2, 4)).as_str(), "c");
 
-        assert_eq!(fb.get_cell(Position::new(1, 4)).as_str(), "b");
-        assert_eq!(fb.get_cell(Position::new(2, 4)).as_str(), "c");
-
-        assert_eq!(fb.get_cell(Position::new(0, 5)).as_str(), "a1");
-        assert_eq!(fb.get_cell(Position::new(0, 6)).as_str(), "a2");
-        assert_eq!(fb.get_cell(Position::new(0, 7)).as_str(), "a3");
-        assert_eq!(fb.get_cell(Position::new(0, 8)).as_str(), "a4");
-        assert_eq!(fb.get_cell(Position::new(0, 9)).as_str(), "a5");
+        assert_eq!(buf.get_cell(Position::new(0, 5)).as_str(), "a1");
+        assert_eq!(buf.get_cell(Position::new(0, 6)).as_str(), "a2");
+        assert_eq!(buf.get_cell(Position::new(0, 7)).as_str(), "a3");
+        assert_eq!(buf.get_cell(Position::new(0, 8)).as_str(), "a4");
+        assert_eq!(buf.get_cell(Position::new(0, 9)).as_str(), "a5");
     }
 }

--- a/germterm/src/core/buffer/builder/mod.rs
+++ b/germterm/src/core/buffer/builder/mod.rs
@@ -3,7 +3,7 @@ pub mod row;
 use crate::{
     cell::Cell,
     core::{
-        buffer::{Buffer, builder::row::BuilderRow, flat::FlatBuffer},
+        buffer::{builder::row::BuilderRow, flat::FlatBuffer, Buffer},
         draw::{Position, Size},
     },
 };
@@ -103,7 +103,7 @@ macro_rules! builder_buffer_item {
     (empty($n:literal)) => {
         BBI::Empty($n)
     };
-    ($($row_stuff:tt)*) => {{
+    ([$($row_stuff:tt)*]) => {{
         BBI::Row($crate::builder_row!($($row_stuff)*))
     }};
 }
@@ -112,7 +112,7 @@ macro_rules! builder_buffer_item {
 #[macro_export]
 macro_rules! builder_buffer_internal  {
     (@munched[$($munched:tt)*] [$($row_content:tt)+] $(, $( $rest:tt)*)?) => {{
-        $crate::builder_buffer_internal!{@munched[$($munched)* $crate::builder_buffer_item!{$($row_content)+}, ] $($($rest)*)?}
+        $crate::builder_buffer_internal!{@munched[$($munched)* $crate::builder_buffer_item!{[$($row_content)+]}, ] $($($rest)*)?}
     }};
     (@munched[$($munched:tt)*] $buffer_item_ident:ident$(($($buffer_item_args:tt)*))? $(, $($rest:tt)*)?) => {{
         $crate::builder_buffer_internal!{@munched[$($munched)* $crate::builder_buffer_item!{$buffer_item_ident$(($($buffer_item_args)*))?}, ] $($($rest)*)?}
@@ -124,6 +124,8 @@ macro_rules! builder_buffer_internal  {
     }};
 }
 
+/// Creates a `BuilderBuffer` at compile time from rows of cells.
+/// Used internally by the `buffer!` macro.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! builder_buffer{
@@ -134,6 +136,7 @@ macro_rules! builder_buffer{
     }};
 }
 
+// This is so we can return an opaque [`Buffer`] from a macro.
 #[doc(hidden)]
 pub fn build_buffer(bb: &BuilderBuffer) -> impl Buffer {
     let mut fb = FlatBuffer::new(bb.size);
@@ -141,6 +144,7 @@ pub fn build_buffer(bb: &BuilderBuffer) -> impl Buffer {
     fb
 }
 
+/// Writes a `BuilderBuffer` into any `Buffer` implementation.
 #[doc(hidden)]
 pub fn build_any_buffer(bb: &BuilderBuffer, buf: &mut dyn Buffer) {
     let mut cursor = Position::ZERO;
@@ -153,7 +157,7 @@ pub fn build_any_buffer(bb: &BuilderBuffer, buf: &mut dyn Buffer) {
                 .checked_add(*n)
                 .expect("Cursor height should never be greater than u16::MAX");
             assert!(
-                cursor.y < sz.height,
+                cursor.y <= sz.height,
                 "Cursor skipped rows should never exceed area height"
             );
         }

--- a/germterm/src/core/buffer/builder/mod.rs
+++ b/germterm/src/core/buffer/builder/mod.rs
@@ -3,7 +3,7 @@ pub mod row;
 use crate::{
     cell::Cell,
     core::{
-        buffer::{builder::row::BuilderRow, flat::FlatBuffer, Buffer},
+        buffer::{Buffer, builder::row::BuilderRow, flat::FlatBuffer},
         draw::{Position, Size},
     },
 };

--- a/germterm/src/core/buffer/builder/mod.rs
+++ b/germterm/src/core/buffer/builder/mod.rs
@@ -210,7 +210,7 @@ pub fn build_any_buffer(bb: &BuilderBuffer, buf: &mut dyn Buffer) {
 /// # Examples
 ///
 /// ```
-/// const BUF: BuilderBuffer = builder_buffer!(
+/// let my_buffer = buffer!(
 ///     ["Header", empty(5), "Value"],
 ///     empty(1),
 ///     [cell("A", Style::EMPTY), "B", "C"],

--- a/germterm/src/core/buffer/builder/mod.rs
+++ b/germterm/src/core/buffer/builder/mod.rs
@@ -31,14 +31,26 @@ impl BuilderBuffer {
     }
 
     const fn height(items: &'static [BuilderBufferItem]) -> u16 {
-        let height = items.len();
+        let mut i = 0;
+        let mut height = 0;
+        while i < items.len() {
+            match items[i] {
+                BuilderBufferItem::Empty(n) => {
+                    height += n;
+                }
+                BuilderBufferItem::Row(_) => {
+                    height += 1;
+                }
+            }
+            i += 1;
+        }
 
         assert!(
-            (u16::MAX as usize) >= height,
+            (u16::MAX as usize) >= height as usize,
             "Unable to determine height of buffer"
         );
 
-        height as u16
+        height
     }
 
     const fn width(items: &'static [BuilderBufferItem]) -> u16 {

--- a/germterm/src/core/buffer/builder/mod.rs
+++ b/germterm/src/core/buffer/builder/mod.rs
@@ -1,0 +1,253 @@
+pub mod row;
+
+use crate::{
+    cell::Cell,
+    core::{
+        buffer::{builder::row::BuilderRow, Buffer},
+        draw::{Position, Size},
+    },
+};
+
+#[doc(hidden)]
+pub struct BuilderBuffer {
+    pub rows: &'static [BuilderBufferItem],
+    pub size: Size,
+}
+
+#[allow(unused)]
+impl BuilderBuffer {
+    const fn new(items: &'static [BuilderBufferItem]) -> Self {
+        Self {
+            rows: items,
+            size: Self::size(items),
+        }
+    }
+
+    const fn size(items: &'static [BuilderBufferItem]) -> Size {
+        let width = Self::width(items);
+        let height = Self::height(items);
+
+        Size::new(width, height)
+    }
+
+    const fn height(items: &'static [BuilderBufferItem]) -> u16 {
+        let height = items.len();
+
+        assert!(
+            (u16::MAX as usize) >= height,
+            "Unable to determine height of buffer"
+        );
+
+        height as u16
+    }
+
+    const fn width(items: &'static [BuilderBufferItem]) -> u16 {
+        let mut i = 0;
+        let mut width = None;
+        while i < items.len() {
+            if let Some(c) = items[i].consumed() {
+                if let Some(width) = width {
+                    assert!(width == c, "Rows of a build buffer must be the same length");
+                }
+
+                width = Some(c);
+            }
+
+            i += 1;
+        }
+
+        if let Some(w) = width {
+            w
+        } else {
+            panic!("Unable to determine width of buffer");
+        }
+    }
+}
+
+/// An item in a builder buffer, representing either a row of cells or skipped lines.
+#[doc(hidden)]
+pub enum BuilderBufferItem {
+    /// Skip `n` rows (vertical space).
+    Empty(u16),
+    /// A row of cells.
+    Row(BuilderRow),
+}
+
+impl BuilderBufferItem {
+    pub const fn consumed(&self) -> Option<u16> {
+        match self {
+            BuilderBufferItem::Empty(_) => None,
+            BuilderBufferItem::Row(builder_row) => Some(builder_row.consumed),
+        }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! builder_buffer_item {
+    (empty($n:literal)) => {
+        BBI::Empty($n)
+    };
+    ($($row_stuff:tt)*) => {{
+        BBI::Row($crate::builder_row!($($row_stuff)*))
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! builder_buffer_internal  {
+    (@munched[$($munched:tt)*] [$($row_content:tt)+] $(, $( $rest:tt)*)?) => {{
+        $crate::builder_buffer_internal!{@munched[$($munched)* $crate::builder_buffer_item!{$($row_content)+}, ] $($($rest)*)?}
+    }};
+    (@munched[$($munched:tt)*] $buffer_item_ident:ident$(($($buffer_item_args:tt)*))? $(, $($rest:tt)*)?) => {{
+        $crate::builder_buffer_internal!{@munched[$($munched)* $crate::builder_buffer_item!{$buffer_item_ident$(($($buffer_item_args)*))?}, ] $($($rest)*)?}
+    }};
+    (@munched[$($finished:tt)*]) => {{
+        const {
+            BB::new(&[$($finished)*])
+        }
+    }};
+}
+
+/// Creates a compile-time buffer layout from rows of cells.
+///
+/// # Syntax
+///
+/// Rows are comma-separated, with each row containing items:
+/// - `"text"` or `cell("text")` - cell with default style
+/// - `cell("text", style)` - cell with custom style
+/// - `empty(n)` - skip n columns
+///
+/// # Examples
+///
+/// ```
+/// const BUF: BuilderBuffer = builder_buffer!(
+///     ["Header", empty(5), "Value"],
+///     empty(1),
+///     [cell("A", Style::EMPTY), "B", "C"],
+/// );
+/// ```
+#[macro_export]
+macro_rules! builder_buffer{
+    ($($tokens:tt)+) => {{
+        #[allow(unused)]
+        use $crate::{
+            core::buffer::builder::{
+                BuilderBuffer as BB, BuilderBufferItem as BBI,
+                row::{
+                    BuilderRowItem as BRI,
+                    BuilderRowItem::{Cell as cell, Empty as empty},
+                },
+            },
+            style::Style as ST,
+        };
+
+        const BUILT_BUFFER: BB = const { $crate::builder_buffer_internal!{@munched[] $($tokens)+} };
+
+        BUILT_BUFFER
+    }};
+}
+
+/// Renders a [`BuilderBuffer`] into a [`Buffer`].
+///
+/// # Panics
+///
+/// Panics if the buffer layout exceeds the target buffer bounds.
+///
+/// # Examples
+///
+/// ```
+/// let mut fb = FlatBuffer::new(layout.size);
+/// build(&layout, &mut fb);
+/// ```
+#[doc(hidden)]
+pub fn build(bb: &BuilderBuffer, buf: &mut dyn Buffer) {
+    let mut cursor = Position::ZERO;
+    let sz = buf.size();
+    bb.rows.iter().for_each(|row| match row {
+        BuilderBufferItem::Empty(n) => {
+            // Both these are checked in [`BuilderBuffer::new`] these are extra assertions just in case.
+            cursor.y = cursor
+                .y
+                .checked_add(*n)
+                .expect("Cursor height should never be greater than u16::MAX");
+            assert!(
+                cursor.y < sz.height,
+                "Cursor skipped rows should never exceed area height"
+            );
+        }
+        BuilderBufferItem::Row(r) => {
+            let items = (r.items)();
+            items.into_iter().for_each(|item| {
+                match item {
+                    row::BuilderRowItem::Cell(s, style) => {
+                        buf.set_cell(cursor, &Cell::new(s, style));
+                        cursor.x = cursor
+                            .x
+                            .checked_add(1)
+                            .expect("Cursor width should never be greater than u16::MAX");
+                        assert!(
+                            cursor.x <= sz.width,
+                            "Cursor skipped rows should never exceed area width"
+                        )
+                    }
+                    row::BuilderRowItem::Empty(n) => {
+                        cursor.x = cursor
+                            .x
+                            .checked_add(n)
+                            .expect("Cursor width should never be greater than u16::MAX");
+                        assert!(
+                            cursor.x <= sz.width,
+                            "Cursor skipped rows should never exceed area width"
+                        )
+                    }
+                };
+            });
+
+            cursor.y = cursor
+                .y
+                .checked_add(1)
+                .expect("Cursor height should never be greater than u16::MAX");
+            cursor.x = 0;
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::buffer::{builder::BuilderBuffer, flat::FlatBuffer, Buffer};
+    use crate::core::draw::Position;
+    use crate::style::Style;
+
+    #[test]
+    fn simple() {
+        use crate::cell::Cell;
+
+        const MY_BUFFER: BuilderBuffer = builder_buffer!(
+            ["a", "b", empty(1)],
+            empty(3),
+            [empty(1), "b", cell("c", Style::EMPTY)],
+            ["a1", "b", "c"],
+            ["a2", "b", "c"],
+            ["a3", "b", "c"],
+            ["a4", "b", "c"],
+            ["a5", "b", "c"]
+        );
+
+        let mut fb = FlatBuffer::new(MY_BUFFER.size);
+        super::build(&MY_BUFFER, &mut fb);
+
+        assert_eq!(fb.get_cell(Position::new(0, 0)).as_str(), "a");
+        assert_eq!(fb.get_cell(Position::new(1, 0)).as_str(), "b");
+        assert_eq!(fb.get_cell(Position::new(2, 0)), &Cell::EMPTY);
+
+        assert_eq!(fb.get_cell(Position::new(1, 4)).as_str(), "b");
+        assert_eq!(fb.get_cell(Position::new(2, 4)).as_str(), "c");
+
+        assert_eq!(fb.get_cell(Position::new(0, 5)).as_str(), "a1");
+        assert_eq!(fb.get_cell(Position::new(0, 6)).as_str(), "a2");
+        assert_eq!(fb.get_cell(Position::new(0, 7)).as_str(), "a3");
+        assert_eq!(fb.get_cell(Position::new(0, 8)).as_str(), "a4");
+        assert_eq!(fb.get_cell(Position::new(0, 9)).as_str(), "a5");
+    }
+}

--- a/germterm/src/core/buffer/builder/mod.rs
+++ b/germterm/src/core/buffer/builder/mod.rs
@@ -121,24 +121,7 @@ macro_rules! builder_buffer_internal  {
     }};
 }
 
-/// Creates a compile-time buffer layout from rows of cells.
-///
-/// # Syntax
-///
-/// Rows are comma-separated, with each row containing items:
-/// - `"text"` or `cell("text")` - cell with default style
-/// - `cell("text", style)` - cell with custom style
-/// - `empty(n)` - skip n columns
-///
-/// # Examples
-///
-/// ```
-/// const BUF: BuilderBuffer = builder_buffer!(
-///     ["Header", empty(5), "Value"],
-///     empty(1),
-///     [cell("A", Style::EMPTY), "B", "C"],
-/// );
-/// ```
+#[doc(hidden)]
 #[macro_export]
 macro_rules! builder_buffer{
     ($($tokens:tt)+) => {{
@@ -223,6 +206,31 @@ pub fn build(bb: &BuilderBuffer, buf: &mut dyn Buffer) {
             cursor.x = 0;
         }
     });
+}
+
+/// Creates a compile-time buffer layout from rows of cells.
+///
+/// # Syntax
+///
+/// Rows are comma-separated, with each row containing items:
+/// - `"text"` or `cell("text")` - cell with default style
+/// - `cell("text", style)` - cell with custom style
+/// - `empty(n)` - skip n columns
+///
+/// # Examples
+///
+/// ```
+/// const BUF: BuilderBuffer = builder_buffer!(
+///     ["Header", empty(5), "Value"],
+///     empty(1),
+///     [cell("A", Style::EMPTY), "B", "C"],
+/// );
+/// ```
+#[macro_export]
+macro_rules! buffer {
+    ($($buffer_contents:tt)*) => {
+        $crate::builder_buffer!{$($buffer_contents)*}
+    };
 }
 
 #[cfg(test)]

--- a/germterm/src/core/buffer/builder/row.rs
+++ b/germterm/src/core/buffer/builder/row.rs
@@ -1,0 +1,177 @@
+use crate::style::Style;
+
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug)]
+pub struct BuilderRow {
+    pub consumed: u16,
+    pub items: fn() -> Box<[BuilderRowItem]>,
+}
+
+#[doc(hidden)]
+pub enum BuilderRowItem {
+    Cell(&'static str, Style),
+    Empty(u16),
+}
+
+impl BuilderRowItem {
+    const fn consumed(&self) -> u16 {
+        match self {
+            Self::Cell(_, _) => 1,
+            Self::Empty(skipped) => *skipped,
+        }
+    }
+}
+
+/// Creates a [`BuilderRowItem`] from a simplified syntax.
+///
+/// This is a helper macro used internally by [`builder_row!`] to convert different
+/// item types into `BuilderRowItem` variants. It is automatically exported so it can
+/// be used in const contexts.
+///
+/// # Note
+///
+/// This macro requires that variants of [`BuilderRow`] are exported as lowercased.
+///
+/// # Syntax
+///
+/// - `empty(n)` - Creates an empty row item that skips `n` cell positions
+/// - `cell("text")` - Creates a cell with the given text and [`Style::EMPTY`]
+/// - `cell("text", style)` - Creates a cell with custom styling
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// // These are typically used within builder_row!:
+/// let item1 = builder_row_item!(empty(5));           // Skip 5 positions
+/// let item2 = builder_row_item!(cell("Hello"));      // Text with default style
+/// let item3 = builder_row_item!(cell("Hi", STYLE));  // Text with custom style
+/// ```
+///
+/// [`BuilderRowItem`]: crate::core::buffer::builder::row::BuilderRowItem
+/// [`Style::EMPTY`]: crate::style::Style::EMPTY
+#[doc(hidden)]
+#[macro_export]
+macro_rules! builder_row_item {
+    ($s:literal) => {
+        cell($s, ST::EMPTY)
+    };
+    (cell($s:literal)) => {
+        cell($s, ST::EMPTY)
+    };
+    ($name:ident($($args:expr),*)) => {
+        $name($($args),*)
+    };
+}
+
+#[doc(hidden)]
+pub const fn consumed_counter(items: &[BuilderRowItem]) -> u16 {
+    let mut i = 0;
+    let mut consumed = 0;
+    while i < items.len() {
+        consumed += items[i].consumed();
+        i += 1;
+    }
+
+    consumed
+}
+
+/// Creates a [`BuilderRow`] at compile time from a list of row items.
+///
+/// This macro constructs a row buffer with cells and empty spaces, calculating
+/// the total consumed cell count at compile time. It is designed to be used
+/// in `const` or `static` contexts testing widget implementations and UI layout.
+///
+/// # Syntax
+///
+/// ```ignore
+/// builder_row!(item1, item2, item3, ...)
+/// ```
+///
+/// Where each item can be:
+/// - `cell("text")` - A cell containing text with default style
+/// - `cell("text", style)` - A cell with custom styling
+/// - `empty(n)` - Skip `n` cell positions (creates empty space)
+///
+/// # Returns
+///
+/// Returns a [`BuilderRow`] struct containing:
+/// - `consumed`: The total number of cell positions this row occupies
+/// - `items`: A function that produces the array of [`BuilderRowItem`]s
+///
+/// # Examples
+///
+/// ## Basic usage with cells
+/// ```rust
+/// use germterm::builder_row;
+///
+/// const ROW: germterm::core::buffer::builder::row::BuilderRow =
+///     builder_row!(cell("Hello"), cell("World"));
+/// ```
+///
+/// ## With custom styling
+/// ```rust
+/// use germterm::{builder_row, style::Style};
+///
+/// const HIGHLIGHT: Style = Style::new().fg(germterm::color::RED);
+/// const ROW: germterm::core::buffer::builder::row::BuilderRow =
+///     builder_row!(cell("Normal"), cell("Important", HIGHLIGHT));
+/// ```
+///
+/// ## With empty spaces
+/// ```rust
+/// use germterm::builder_row;
+///
+/// // Creates a row with "Left", 5 empty positions, then "Right"
+/// const ROW: germterm::core::buffer::builder::row::BuilderRow =
+///     builder_row!(cell("Left"), empty(5), cell("Right"));
+/// ```
+///
+/// ## Compile-time construction
+/// ```rust
+/// use germterm::builder_row;
+///
+/// // These are evaluated at compile time with no runtime overhead
+/// static STATIC_ROW: germterm::core::buffer::builder::row::BuilderRow =
+///     builder_row!(cell("Static"));
+/// const CONST_ROW: germterm::core::buffer::builder::row::BuilderRow =
+///     builder_row!(cell("Const"));
+/// ```
+///
+/// [`BuilderRow`]: crate::core::buffer::builder::row::BuilderRow
+/// [`BuilderRowItem`]: crate::core::buffer::builder::row::BuilderRowItem
+#[doc(hidden)]
+#[macro_export]
+macro_rules! builder_row {
+    ($($row_item_ident:tt$(($($row_item_args:expr),*))?),*) => {{
+        use $crate::core::buffer::builder;
+        #[allow(unused_imports)]
+        const CONSUMED: u16 = builder::row::consumed_counter(&[$($crate::builder_row_item!($row_item_ident$(($($row_item_args),*))?)),*]);
+        fn rows() -> Box<[BRI]> {
+            let items = [$($crate::builder_row_item!($row_item_ident$(($($row_item_args),*))?)),*];
+            Box::new(items)
+        }
+
+       builder::row::BuilderRow {consumed: CONSUMED, items: rows}
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::buffer::builder::row::BuilderRowItem::{Cell as cell, Empty as empty};
+    use crate::core::buffer::builder::row::{BuilderRow, BuilderRowItem as BRI};
+    use crate::style::Style as ST;
+
+    static ROW_STATIC: BuilderRow = crate::builder_row!("a");
+    const ROW_CONST: BuilderRow = crate::builder_row!(cell("a", ST::EMPTY));
+
+    #[test]
+    fn build_row() {
+        // This is to ensure that we can construct the values at compile time.
+        //
+        // Alternative implementations should not produce warnings related interior mutability with
+        // the declarations below.
+        static ROW_STATIC: BuilderRow = crate::builder_row!("a");
+        const ROW_CONST: BuilderRow = crate::builder_row!(cell("a", ST::EMPTY));
+        assert_eq!(ROW_STATIC.consumed, ROW_CONST.consumed);
+    }
+}

--- a/germterm/src/core/buffer/builder/row.rs
+++ b/germterm/src/core/buffer/builder/row.rs
@@ -157,11 +157,13 @@ macro_rules! builder_row {
 
 #[cfg(test)]
 mod tests {
-    use crate::core::buffer::builder::row::BuilderRowItem::{Cell as cell, Empty as empty};
+    use crate::core::buffer::builder::row::BuilderRowItem::{Cell as cell};
     use crate::core::buffer::builder::row::{BuilderRow, BuilderRowItem as BRI};
     use crate::style::Style as ST;
 
+    #[allow(unused)]
     static ROW_STATIC: BuilderRow = crate::builder_row!("a");
+    #[allow(unused)]
     const ROW_CONST: BuilderRow = crate::builder_row!(cell("a", ST::EMPTY));
 
     #[test]

--- a/germterm/src/core/buffer/builder/row.rs
+++ b/germterm/src/core/buffer/builder/row.rs
@@ -157,7 +157,7 @@ macro_rules! builder_row {
 
 #[cfg(test)]
 mod tests {
-    use crate::core::buffer::builder::row::BuilderRowItem::{Cell as cell};
+    use crate::core::buffer::builder::row::BuilderRowItem::Cell as cell;
     use crate::core::buffer::builder::row::{BuilderRow, BuilderRowItem as BRI};
     use crate::style::Style as ST;
 

--- a/germterm/src/core/buffer/diffed.rs
+++ b/germterm/src/core/buffer/diffed.rs
@@ -65,7 +65,7 @@ impl<Buf: Buffer> Buffer for DiffedBuffers<Buf> {
     fn set_cell_checked(
         &mut self,
         pos: Position,
-        cell: Cell,
+        cell: &Cell,
     ) -> Result<(), super::ErrorOutOfBoundsAxises> {
         let idx = self.frame_order as usize;
         self.cells[idx].set_cell_checked(pos, cell)
@@ -84,7 +84,7 @@ impl<Buf: Buffer> Buffer for DiffedBuffers<Buf> {
         self.cells[idx].get_cell_mut_checked(pos)
     }
 
-    fn fill(&mut self, cell: Cell) {
+    fn fill(&mut self, cell: &Cell) {
         let idx = self.frame_order as usize;
         self.cells[idx].fill(cell);
     }

--- a/germterm/src/core/buffer/flat.rs
+++ b/germterm/src/core/buffer/flat.rs
@@ -42,13 +42,13 @@ impl Buffer for FlatBuffer {
     fn set_cell_checked(
         &mut self,
         pos: Position,
-        cell: Cell,
+        cell: &Cell,
     ) -> Result<(), ErrorOutOfBoundsAxises> {
         if let err @ Err(_) = self.size.contains(pos) {
             cold();
             return err;
         }
-        self.cells[pos.to_index(self.size.width)] = cell;
+        self.cells[pos.to_index(self.size.width)].clone_from(cell);
         Ok(())
     }
 
@@ -68,8 +68,8 @@ impl Buffer for FlatBuffer {
         Ok(&mut self.cells[pos.to_index(self.size.width)])
     }
 
-    fn fill(&mut self, cell: Cell) {
-        self.cells.fill(cell);
+    fn fill(&mut self, cell: &Cell) {
+        self.cells.iter_mut().for_each(|c| c.clone_from(cell));
     }
 
     fn start_frame(&mut self) {
@@ -116,8 +116,8 @@ impl ResizableBuffer for FlatBuffer {
         // NOTE: I have no idea why Cell would be unpin but if it somehow does this gives a compile error
         // rather than UB.
         #[allow(unused)]
-        fn is_copy<T: Unpin>(arg: &T) {
-            let _ = || is_copy::<Cell>(&Cell::EMPTY);
+        fn is_unpin<T: Unpin>(arg: &T) {
+            let _ = || is_unpin::<Cell>(&Cell::EMPTY);
         }
         let new_temp_len = (self.size.height as usize) * (size.width as usize);
 
@@ -140,29 +140,46 @@ impl ResizableBuffer for FlatBuffer {
                         let src = base.add(y * old_w);
                         let dst = base.add(y * new_w);
                         ptr::copy(src, dst, old_w);
-
-                        // Fill the new columns at the end of this row.
-                        std::slice::from_raw_parts_mut(dst.add(old_w), grow_by).fill(Cell::EMPTY);
+                        for i in 0..grow_by {
+                            dst.add(old_w + i).write(Cell::EMPTY);
+                        }
                     }
 
                     // Row 0: fill trailing gap last, after all rows have been
                     // scattered, so that row 1's old data is not overwritten.
                     if old_h > 0 {
-                        std::slice::from_raw_parts_mut(base.add(old_w), grow_by).fill(Cell::EMPTY);
+                        for i in 0..grow_by {
+                            base.add(old_w + i).write(Cell::EMPTY);
+                        }
                     }
 
                     self.cells.set_len(new_temp_len);
                 }
             }
             // Shrink case
-            Ordering::Greater => unsafe {
-                let base = self.cells.as_mut_ptr();
-                for y in 1..old_h {
-                    ptr::copy(base.add(y * old_w), base.add(y * new_w), new_w);
+            Ordering::Greater => {
+                let dif = old_w - new_w;
+
+                // Drop extra columns for each row, starting from the last row
+                // to avoid overwriting data we still need.
+                for y in (0..old_h).rev() {
+                    let extra_start = y * old_w + new_w;
+                    unsafe {
+                        ptr::slice_from_raw_parts_mut(self.cells.as_mut_ptr().add(extra_start), dif)
+                            .drop_in_place()
+                    };
                 }
 
-                self.cells.set_len(new_temp_len);
-            },
+                // Compact rows
+                for y in 1..old_h {
+                    unsafe {
+                        let base = self.cells.as_mut_ptr();
+                        ptr::copy(base.add(y * old_w), base.add(y * new_w), new_w);
+                    }
+                }
+
+                self.cells.truncate(new_temp_len);
+            }
             Ordering::Equal => {}
         }
 

--- a/germterm/src/core/buffer/mod.rs
+++ b/germterm/src/core/buffer/mod.rs
@@ -85,7 +85,7 @@ pub trait Buffer {
         let size = self.size();
         for y in 0..size.height {
             for x in 0..size.width {
-                self.get_cell_mut(Position { x, y }).clone_from(&cell);
+                self.get_cell_mut(Position { x, y }).clone_from(cell);
             }
         }
     }

--- a/germterm/src/core/buffer/mod.rs
+++ b/germterm/src/core/buffer/mod.rs
@@ -1,3 +1,4 @@
+pub mod builder;
 pub mod diffed;
 pub mod flat;
 pub mod paired;
@@ -33,14 +34,17 @@ pub trait Buffer {
     fn size(&self) -> Size;
 
     /// Sets the cell at `pos`, returning an error if `pos` is outside bounds.
-    fn set_cell_checked(&mut self, pos: Position, cell: Cell)
-    -> Result<(), ErrorOutOfBoundsAxises>;
+    fn set_cell_checked(
+        &mut self,
+        pos: Position,
+        cell: &Cell,
+    ) -> Result<(), ErrorOutOfBoundsAxises>;
     /// Sets the cell at `pos` without bounds checking.
     ///
     /// # Panics
     ///
     /// Panics if `pos` is out of bounds.
-    fn set_cell(&mut self, pos: Position, cell: Cell) {
+    fn set_cell(&mut self, pos: Position, cell: &Cell) {
         self.set_cell_checked(pos, cell)
             .expect("out of bounds set_cell")
     }
@@ -77,18 +81,18 @@ pub trait Buffer {
     }
 
     /// Fills the entire buffer with `cell`.
-    fn fill(&mut self, cell: Cell) {
+    fn fill(&mut self, cell: &Cell) {
         let size = self.size();
         for y in 0..size.height {
             for x in 0..size.width {
-                self.set_cell(Position { x, y }, cell);
+                self.get_cell_mut(Position { x, y }).clone_from(&cell);
             }
         }
     }
 
     /// Clears the buffer by filling it with [`Cell::EMPTY`].
     fn clear(&mut self) {
-        self.fill(Cell::EMPTY);
+        self.fill(&Cell::EMPTY);
     }
 
     /// Called at the beginning of a frame. Implementations may use this to

--- a/germterm/src/core/buffer/paired.rs
+++ b/germterm/src/core/buffer/paired.rs
@@ -80,7 +80,7 @@ impl Buffer for PairedBuffer {
     fn set_cell_checked(
         &mut self,
         pos: Position,
-        cell: Cell,
+        cell: &Cell,
     ) -> Result<(), super::ErrorOutOfBoundsAxises> {
         if let err @ Err(_) = self.size.contains(pos) {
             cold();
@@ -88,7 +88,7 @@ impl Buffer for PairedBuffer {
         }
 
         let cur = self.index_current();
-        self.frames[pos.to_index(self.size.width)][cur] = cell;
+        self.frames[pos.to_index(self.size.width)][cur].clone_from(cell);
         Ok(())
     }
 
@@ -112,10 +112,10 @@ impl Buffer for PairedBuffer {
         Ok(&mut self.frames[pos.to_index(self.size.width)][cur])
     }
 
-    fn fill(&mut self, cell: Cell) {
+    fn fill(&mut self, cell: &Cell) {
         let cur = self.index_current();
         for frame in &mut self.frames {
-            frame[cur] = cell;
+            frame[cur].clone_from(&cell);
         }
     }
 

--- a/germterm/src/core/buffer/paired.rs
+++ b/germterm/src/core/buffer/paired.rs
@@ -115,7 +115,7 @@ impl Buffer for PairedBuffer {
     fn fill(&mut self, cell: &Cell) {
         let cur = self.index_current();
         for frame in &mut self.frames {
-            frame[cur].clone_from(&cell);
+            frame[cur].clone_from(cell);
         }
     }
 

--- a/germterm/src/core/buffer/slice.rs
+++ b/germterm/src/core/buffer/slice.rs
@@ -170,7 +170,7 @@ impl<Buf: Buffer + ?Sized> Buffer for SubBuffer<'_, Buf> {
     fn set_cell_checked(
         &mut self,
         pos: Position,
-        cell: Cell,
+        cell: &Cell,
     ) -> Result<(), super::ErrorOutOfBoundsAxises> {
         let translated = match self.translate(pos) {
             Ok(it) => it,
@@ -214,6 +214,8 @@ impl<Buf: Buffer + ?Sized> Buffer for SubBuffer<'_, Buf> {
 // type a bit of unsafe to reduce duplication.
 #[cfg(test)]
 mod tests {
+    use std::{ops::Deref, sync::LazyLock};
+
     use crate::{
         buffer_tests,
         cell::Cell,
@@ -221,13 +223,12 @@ mod tests {
             buffer::{Buffer, paired::PairedBuffer, slice::SubBuffer},
             draw::{Position, Rect, Size},
         },
+        style::Style,
     };
 
     pub const SCALE: u16 = 2;
-    pub const TEST_CELL: Cell = Cell {
-        ch: '森',
-        ..Cell::EMPTY
-    };
+
+    pub static TEST_CELL: LazyLock<Cell> = LazyLock::new(|| Cell::new("森", Style::EMPTY));
 
     struct OwnedSubBuffer(SubBuffer<'static, PairedBuffer>);
 
@@ -235,7 +236,7 @@ mod tests {
         fn new(sz: Size) -> Self {
             let nsz = sz.scale(SCALE);
             let inner = Box::leak(Box::new(PairedBuffer::new(nsz)));
-            inner.fill(TEST_CELL);
+            inner.fill(&TEST_CELL);
 
             SubBuffer::new(inner, Rect::new(Position::ZERO, sz)).clear();
             OwnedSubBuffer(SubBuffer::new(inner, Rect::new(Position::ZERO, sz)))
@@ -258,7 +259,7 @@ mod tests {
                     let pos = Position::new(x, y);
                     assert_eq!(
                         inner.get_cell(pos),
-                        &TEST_CELL,
+                        TEST_CELL.deref(),
                         "Mismatch of cell in {pos:?}"
                     );
                 }
@@ -270,7 +271,7 @@ mod tests {
                     let pos = Position::new(x, y);
                     assert_eq!(
                         inner.get_cell(pos),
-                        &TEST_CELL,
+                        TEST_CELL.deref(),
                         "Mismatch of cell in {pos:?}"
                     );
                 }
@@ -282,7 +283,7 @@ mod tests {
                     let pos = Position::new(x, y);
                     assert_eq!(
                         inner.get_cell(pos),
-                        &TEST_CELL,
+                        TEST_CELL.deref(),
                         "Mismatch of cell in {pos:?}"
                     );
                 }
@@ -291,7 +292,7 @@ mod tests {
     }
 
     impl Buffer for OwnedSubBuffer {
-        fn set_cell(&mut self, pos: Position, cell: crate::cell::Cell) {
+        fn set_cell(&mut self, pos: Position, cell: &crate::cell::Cell) {
             self.0
                 .set_cell_checked(pos, cell)
                 .expect("out of bounds set_cell")
@@ -309,12 +310,12 @@ mod tests {
                 .expect("out of bounds get_cell_mut")
         }
 
-        fn fill(&mut self, cell: crate::cell::Cell) {
+        fn fill(&mut self, cell: &crate::cell::Cell) {
             self.0.fill(cell);
         }
 
         fn clear(&mut self) {
-            self.0.fill(crate::cell::Cell::EMPTY);
+            self.0.fill(&crate::cell::Cell::EMPTY);
         }
 
         fn start_frame(&mut self) {
@@ -332,7 +333,7 @@ mod tests {
         fn set_cell_checked(
             &mut self,
             pos: Position,
-            cell: crate::cell::Cell,
+            cell: &crate::cell::Cell,
         ) -> Result<(), crate::core::buffer::ErrorOutOfBoundsAxises> {
             self.0.set_cell_checked(pos, cell)
         }

--- a/germterm/src/core/buffer/test.rs
+++ b/germterm/src/core/buffer/test.rs
@@ -890,17 +890,18 @@ pub fn fmt_diff(
     mut diff: impl Iterator<Item = (Position, CellDiff)>,
 ) -> Result<usize, core::fmt::Error> {
     let mut count = 0;
+    writeln!(w, "[expected - found]")?;
     diff.try_for_each(|(pos, cd)| {
+        write!(w, "{pos:?}")?;
         count += 1;
-        writeln!(w, "{pos:?} [expected - found]")?;
         if let Some(fg) = cd.fg {
-            write!(w, "fg [{:?} - {:?}] ", fg.expected, fg.found)?;
+            write!(w, " fg [{:?} - {:?}] ", fg.expected, fg.found)?;
         }
         if let Some(bg) = cd.bg {
-            write!(w, "bg [{:?} - {:?}] ", bg.expected, bg.found)?;
+            write!(w, " bg [{:?} - {:?}] ", bg.expected, bg.found)?;
         }
         if let Some(ch) = cd.ch {
-            write!(w, "ch [{:?} - {:?}]", ch.expected, ch.found)?;
+            write!(w, " ch [{:?} - {:?}]", ch.expected, ch.found)?;
         }
 
         writeln!(w)
@@ -911,14 +912,18 @@ pub fn fmt_diff(
 
 #[macro_export]
 macro_rules! buf_assert_eq {
-    ($lhs:expr, $rhs:expr, $msg:expr) => {{
+    ($lhs:expr, $rhs:expr) => {{
         let lhs = $lhs;
         let rhs = $rhs;
 
         let mut s = String::new();
-        let count = $crate::core::buffer::test::fmt_diff(&mut s, $crate::core::buffer::utils::buf_cmp(&lhs, &rhs)).unwrap();
+        let count = $crate::core::buffer::test::fmt_diff(
+            &mut s,
+            $crate::core::buffer::utils::buf_cmp(&lhs, &rhs),
+        )
+        .unwrap();
         if count != 0 {
-            panic!("Buffer assertion failed\n{}", s)
+            panic!("Buffer assertion failed:\n{s}")
         }
     }};
 }

--- a/germterm/src/core/buffer/test.rs
+++ b/germterm/src/core/buffer/test.rs
@@ -1,8 +1,10 @@
+use std::fmt::Write;
+
 use crate::{
-    cell::{Cell, CellFormat},
+    cell::Cell,
     color::Color,
     core::{
-        buffer::{Buffer, Drawer, slice::SubBuffer},
+        buffer::{Buffer, Drawer, slice::SubBuffer, utils::CellDiff},
         draw::{Position, Rect},
     },
     style::{Attributes, Style},
@@ -14,7 +16,7 @@ pub fn fill_buffer_cell_for_pos<Buf: Buffer>(buf: &mut Buf) {
     for y in 0..sz.height {
         for x in 0..sz.width {
             let pos = Position::new(x, y);
-            buf.set_cell(pos, cell_for_pos(pos));
+            buf.set_cell(pos, &cell_for_pos(pos));
         }
     }
 }
@@ -50,34 +52,32 @@ pub fn cell_for_pos(pos: Position) -> Cell {
     let [x1, x2] = pos.x.to_be_bytes();
     let [y1, y2] = pos.y.to_be_bytes();
 
-    const ASCII_LOWER: [u8; 26] = [
-        b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h', b'i', b'j', b'k', b'l', b'm', b'n', b'o',
-        b'p', b'q', b'r', b's', b't', b'u', b'v', b'w', b'x', b'y', b'z',
+    const ASCII_LOWER: [&str; 26] = [
+        "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r",
+        "s", "t", "u", "v", "w", "x", "y", "z",
     ];
-    const ASCII_UPPER: [u8; 26] = [
-        b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H', b'I', b'J', b'K', b'L', b'M', b'N', b'O',
-        b'P', b'Q', b'R', b'S', b'T', b'U', b'V', b'W', b'X', b'Y', b'Z',
+    const ASCII_UPPER: [&str; 26] = [
+        "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R",
+        "S", "T", "U", "V", "W", "X", "Y", "Z",
     ];
-    const ASCII: &[u8] = [ASCII_LOWER, ASCII_UPPER].as_flattened();
+    const ASCII: &[&str] = [ASCII_LOWER, ASCII_UPPER].as_flattened();
 
-    Cell {
-        ch: char::from(ASCII[(x1 ^ x2 ^ y1 ^ y2 ^ 47) as usize % ASCII.len()]),
-        style: Style::new(
-            Color::new(x1, x2, y1, y2),
-            Color::new(x2, x1, y2, y1),
-            Attributes::empty(),
-        ),
-        format: CellFormat::Standard,
-    }
+    let s = ASCII[(x1 ^ x2 ^ y1 ^ y2 ^ 47) as usize % ASCII.len()];
+    let style = Style::new(
+        Color::new(x1, x2, y1, y2),
+        Color::new(x2, x1, y2, y1),
+        Attributes::empty(),
+    );
+    Cell::new(s, style)
 }
 
 #[doc(hidden)]
 pub fn draw_sorted<Buf: Buffer + Drawer>(buf: &mut Buf) -> Vec<(u16, u16, Cell)> {
     let mut calls: Vec<_> = buf
         .draw()
-        .map(|dc| (dc.pos.x, dc.pos.y, *dc.cell))
+        .map(|dc| (dc.pos.x, dc.pos.y, dc.cell.clone()))
         .collect();
-    calls.sort_by(|&(_, _, c1), &(_, _, c2)| c1.ch.cmp(&c2.ch));
+    calls.sort_by(|(_, _, c1), (_, _, c2)| c1.as_str().cmp(c2.as_str()));
     buf.end_frame();
     buf.start_frame();
     calls
@@ -153,7 +153,7 @@ macro_rules! buffer_tests {
             fn set_and_get_cell_checked_origin() {
                 let mut buf = new_buf(Size::new(5, 5));
                 let pos = Position::ZERO;
-                buf.set_cell_checked(pos, cell_for_pos(pos)).unwrap();
+                buf.set_cell_checked(pos, &cell_for_pos(pos)).unwrap();
                 assert_eq!(buf.get_cell_checked(pos).unwrap(), &cell_for_pos(pos));
             }
 
@@ -161,7 +161,7 @@ macro_rules! buffer_tests {
             fn set_and_get_cell_checked_last_valid() {
                 let mut buf = new_buf(Size::new(5, 5));
                 let pos = Position::new(4, 4);
-                buf.set_cell_checked(pos, cell_for_pos(pos)).unwrap();
+                buf.set_cell_checked(pos, &cell_for_pos(pos)).unwrap();
                 assert_eq!(buf.get_cell_checked(pos).unwrap(), &cell_for_pos(pos));
             }
 
@@ -169,7 +169,7 @@ macro_rules! buffer_tests {
             fn set_and_get_cell_checked_arbitrary() {
                 let mut buf = new_buf(Size::new(8, 6));
                 let pos = Position::new(3, 2);
-                buf.set_cell_checked(pos, cell_for_pos(pos)).unwrap();
+                buf.set_cell_checked(pos, &cell_for_pos(pos)).unwrap();
                 assert_eq!(buf.get_cell_checked(pos).unwrap(), &cell_for_pos(pos));
             }
 
@@ -177,7 +177,7 @@ macro_rules! buffer_tests {
             fn set_cell_checked_x_out_of_bounds() {
                 let mut buf = new_buf(Size::new(4, 4));
                 let err = buf
-                    .set_cell_checked(Position::new(4, 0), cell_for_pos(Position::ZERO))
+                    .set_cell_checked(Position::new(4, 0), &cell_for_pos(Position::ZERO))
                     .unwrap_err();
                 assert_eq!(err, ErrorOutOfBoundsAxises::X);
             }
@@ -186,7 +186,7 @@ macro_rules! buffer_tests {
             fn set_cell_checked_y_out_of_bounds() {
                 let mut buf = new_buf(Size::new(4, 4));
                 let err = buf
-                    .set_cell_checked(Position::new(0, 4), cell_for_pos(Position::ZERO))
+                    .set_cell_checked(Position::new(0, 4), &cell_for_pos(Position::ZERO))
                     .unwrap_err();
                 assert_eq!(err, ErrorOutOfBoundsAxises::Y);
             }
@@ -195,7 +195,7 @@ macro_rules! buffer_tests {
             fn set_cell_checked_xy_out_of_bounds() {
                 let mut buf = new_buf(Size::new(4, 4));
                 let err = buf
-                    .set_cell_checked(Position::new(4, 4), cell_for_pos(Position::ZERO))
+                    .set_cell_checked(Position::new(4, 4), &cell_for_pos(Position::ZERO))
                     .unwrap_err();
                 assert_eq!(err, ErrorOutOfBoundsAxises::XY);
             }
@@ -227,7 +227,7 @@ macro_rules! buffer_tests {
             fn set_and_get_cell_infallible() {
                 let mut buf = new_buf(Size::new(5, 5));
                 let pos = Position::new(2, 3);
-                buf.set_cell(pos, cell_for_pos(pos));
+                buf.set_cell(pos, &cell_for_pos(pos));
                 assert_eq!(buf.get_cell(pos), &cell_for_pos(pos));
             }
 
@@ -235,7 +235,7 @@ macro_rules! buffer_tests {
             #[should_panic]
             fn set_cell_panics_out_of_bounds() {
                 let mut buf = new_buf(Size::new(4, 4));
-                buf.set_cell(Position::new(10, 10), cell_for_pos(Position::ZERO));
+                buf.set_cell(Position::new(10, 10), &cell_for_pos(Position::ZERO));
             }
 
             #[test]
@@ -300,8 +300,8 @@ macro_rules! buffer_tests {
                 let mut buf = new_buf(Size::new(4, 4));
                 let pos_a = Position::ZERO;
                 let pos_b = Position::new(3, 3);
-                buf.set_cell(pos_a, cell_for_pos(pos_a));
-                buf.set_cell(pos_b, cell_for_pos(pos_b));
+                buf.set_cell(pos_a, &cell_for_pos(pos_a));
+                buf.set_cell(pos_b, &cell_for_pos(pos_b));
                 assert_eq!(buf.get_cell(pos_a), &cell_for_pos(pos_a));
                 assert_eq!(buf.get_cell(pos_b), &cell_for_pos(pos_b));
             }
@@ -312,9 +312,9 @@ macro_rules! buffer_tests {
                 let pos0 = Position::ZERO;
                 let pos1 = Position::new(1, 0);
                 let pos2 = Position::new(2, 0);
-                buf.set_cell(pos0, cell_for_pos(pos0));
-                buf.set_cell(pos1, cell_for_pos(pos1));
-                buf.set_cell(pos2, cell_for_pos(pos2));
+                buf.set_cell(pos0, &cell_for_pos(pos0));
+                buf.set_cell(pos1, &cell_for_pos(pos1));
+                buf.set_cell(pos2, &cell_for_pos(pos2));
                 assert_eq!(buf.get_cell(pos0), &cell_for_pos(pos0));
                 assert_eq!(buf.get_cell(pos1), &cell_for_pos(pos1));
                 assert_eq!(buf.get_cell(pos2), &cell_for_pos(pos2));
@@ -328,8 +328,8 @@ macro_rules! buffer_tests {
                 let pos = Position::new(1, 1);
                 let first = cell_for_pos(Position::ZERO);
                 let second = cell_for_pos(Position::new(1, 0));
-                buf.set_cell(pos, first);
-                buf.set_cell(pos, second.clone());
+                buf.set_cell(pos, &first);
+                buf.set_cell(pos, &second.clone());
                 assert_eq!(buf.get_cell(pos), &second);
             }
 
@@ -340,7 +340,7 @@ macro_rules! buffer_tests {
                 let size = Size::new(4, 3);
                 let mut buf = new_buf(size);
                 let fill_cell = cell_for_pos(Position::ZERO);
-                buf.fill(fill_cell.clone());
+                buf.fill(&fill_cell);
                 for y in 0..size.height {
                     for x in 0..size.width {
                         assert_eq!(
@@ -358,7 +358,7 @@ macro_rules! buffer_tests {
             fn clear_sets_every_cell_to_empty() {
                 let size = Size::new(4, 3);
                 let mut buf = new_buf(size);
-                buf.fill(cell_for_pos(Position::ZERO));
+                buf.fill(&cell_for_pos(Position::ZERO));
                 buf.clear();
                 for y in 0..size.height {
                     for x in 0..size.width {
@@ -438,7 +438,7 @@ macro_rules! drawer_buffer_tests {
             fn draw_emits_all_cells_when_unchanged() {
                 let size = Size::new(3, 2);
                 let mut buf = new_buf(size);
-                buf.fill(cell_for_pos(Position::ZERO));
+                buf.fill(&cell_for_pos(Position::ZERO));
                 let _ = draw_sorted(&mut buf); // first draw
                 // Nothing written to the buffer between draws.
                 let calls = draw_sorted(&mut buf);
@@ -457,17 +457,17 @@ macro_rules! drawer_buffer_tests {
                 let mut buf = new_buf(size);
                 let pos_a = Position::ZERO;
                 let pos_b = Position::new(1, 1);
-                buf.set_cell(pos_a, cell_for_pos(pos_a));
-                buf.set_cell(pos_b, cell_for_pos(pos_b));
+                buf.set_cell(pos_a, &cell_for_pos(pos_a));
+                buf.set_cell(pos_b, &cell_for_pos(pos_b));
                 let calls = draw_sorted(&mut buf);
                 let find = |x, y| calls.iter().find(|&&(cx, cy, _)| cx == x && cy == y);
                 assert_eq!(
-                    find(pos_a.x, pos_a.y).map(|&(_, _, ch)| ch),
-                    Some(cell_for_pos(pos_a))
+                    find(pos_a.x, pos_a.y).map(|(_, _, ch)| ch),
+                    Some(cell_for_pos(pos_a)).as_ref()
                 );
                 assert_eq!(
-                    find(pos_b.x, pos_b.y).map(|&(_, _, ch)| ch),
-                    Some(cell_for_pos(pos_b))
+                    find(pos_b.x, pos_b.y).map(|(_, _, ch)| ch),
+                    Some(cell_for_pos(pos_b)).as_ref()
                 );
             }
 
@@ -478,7 +478,7 @@ macro_rules! drawer_buffer_tests {
                 let size = Size::new(4, 3);
                 let mut buf = new_buf(size);
                 let pos = Position::new(1, 1);
-                buf.set_cell(pos, cell_for_pos(pos));
+                buf.set_cell(pos, &cell_for_pos(pos));
                 let calls = draw_sorted(&mut buf);
                 assert_eq!(
                     calls.len(),
@@ -539,7 +539,7 @@ macro_rules! drawer_diffed_buffer_tests {
                 let _ = draw_sorted(&mut buf); // swap: new current frame is blank
 
                 let pos = Position::new(1, 2);
-                buf.set_cell(pos, cell_for_pos(pos));
+                buf.set_cell(pos, &cell_for_pos(pos));
                 let calls = draw_sorted(&mut buf);
                 assert_eq!(calls, [(pos.x, pos.y, cell_for_pos(pos))]);
             }
@@ -552,11 +552,11 @@ macro_rules! drawer_diffed_buffer_tests {
                 let _ = draw_sorted(&mut buf);
 
                 let pos = Position::ZERO;
-                buf.set_cell(pos, cell_for_pos(pos));
+                buf.set_cell(pos, &cell_for_pos(pos));
                 let _ = draw_sorted(&mut buf); // cell_for_pos(pos) is now in the old frame
 
                 // Write the same value again - no diff.
-                buf.set_cell(pos, cell_for_pos(pos));
+                buf.set_cell(pos, &cell_for_pos(pos));
                 assert_eq!(
                     draw_sorted(&mut buf).len(),
                     0,
@@ -576,7 +576,7 @@ macro_rules! drawer_diffed_buffer_tests {
                 for y in 0..size.height {
                     for x in 0..size.width {
                         let pos = Position::new(x, y);
-                        buf.set_cell(pos, cell_for_pos(pos));
+                        buf.set_cell(pos, &cell_for_pos(pos));
                     }
                 }
                 let _ = draw_sorted(&mut buf);
@@ -585,7 +585,7 @@ macro_rules! drawer_diffed_buffer_tests {
                 // (start_frame cleared them), so every position except (2,2) differs
                 // from its old value.
                 let pos_changed = Position::new(2, 2);
-                buf.set_cell(pos_changed, cell_for_pos(pos_changed));
+                buf.set_cell(pos_changed, &cell_for_pos(pos_changed));
                 let calls = draw_sorted(&mut buf);
 
                 // (2,2) is unchanged (same cell as old frame), so it must NOT appear.
@@ -613,15 +613,15 @@ macro_rules! drawer_diffed_buffer_tests {
 
                 let pos_a = Position::new(1, 1);
                 let pos_b = Position::new(2, 1);
-                buf.set_cell(pos_a, cell_for_pos(pos_a));
+                buf.set_cell(pos_a, &cell_for_pos(pos_a));
                 let _ = draw_sorted(&mut buf); // cell_for_pos(pos_a) is now old frame
 
-                buf.set_cell(pos_a, cell_for_pos(pos_b));
+                buf.set_cell(pos_a, &cell_for_pos(pos_b));
                 let calls = draw_sorted(&mut buf);
                 assert!(
-                    calls.iter().any(|&(x, y, ch)| x == pos_a.x
-                        && y == pos_a.y
-                        && ch == cell_for_pos(pos_b)),
+                    calls.iter().any(|(x, y, ch)| *x == pos_a.x
+                        && *y == pos_a.y
+                        && ch.clone() == cell_for_pos(pos_b)),
                     "overwritten cell must be emitted with its new value"
                 );
             }
@@ -634,7 +634,7 @@ macro_rules! drawer_diffed_buffer_tests {
                 let _ = draw_sorted(&mut buf);
 
                 let pos = Position::new(2, 2);
-                buf.set_cell(pos, cell_for_pos(pos));
+                buf.set_cell(pos, &cell_for_pos(pos));
                 let _ = draw_sorted(&mut buf); // cell_for_pos(pos) is now old frame
 
                 // Current frame is blank (start_frame cleared it); (2,2) now
@@ -658,10 +658,10 @@ macro_rules! drawer_diffed_buffer_tests {
                 // start_frame cleared the current frame; old frame is EMPTY.
                 // Write fill_cell and draw so old frame becomes fill_cell everywhere.
                 let fill_cell = cell_for_pos(Position::ZERO);
-                buf.fill(fill_cell.clone());
+                buf.fill(&fill_cell);
                 let _ = draw_sorted(&mut buf);
                 // start_frame cleared current frame; write fill_cell again to match old.
-                buf.fill(fill_cell);
+                buf.fill(&fill_cell);
                 assert_eq!(
                     draw_sorted(&mut buf).len(),
                     0,
@@ -677,7 +677,7 @@ macro_rules! drawer_diffed_buffer_tests {
                 let mut buf = new_buf(size);
                 let _ = draw_sorted(&mut buf); // old frame = EMPTY, current = fresh blank
 
-                buf.fill(cell_for_pos(Position::ZERO));
+                buf.fill(&cell_for_pos(Position::ZERO));
                 let calls = draw_sorted(&mut buf);
                 assert_eq!(
                     calls.len(),
@@ -695,8 +695,8 @@ macro_rules! drawer_diffed_buffer_tests {
 
                 let pos_a = Position::ZERO;
                 let pos_b = Position::new(3, 3);
-                buf.set_cell(pos_a, cell_for_pos(pos_a));
-                buf.set_cell(pos_b, cell_for_pos(pos_b));
+                buf.set_cell(pos_a, &cell_for_pos(pos_a));
+                buf.set_cell(pos_b, &cell_for_pos(pos_b));
                 let calls = draw_sorted(&mut buf);
                 assert_eq!(
                     calls,
@@ -805,7 +805,7 @@ macro_rules! buffer_resizing_tests {
                 let new_size = Size::new(7, 3);
                 buf.resize(new_size);
                 let pos = Position::new(new_size.width - 1, new_size.height - 1);
-                buf.set_cell(pos, cell_for_pos(pos));
+                buf.set_cell(pos, &cell_for_pos(pos));
                 assert_eq!(buf.get_cell(pos), &cell_for_pos(pos));
             }
 
@@ -882,4 +882,43 @@ macro_rules! buffer_resizing_tests {
             }
         }
     };
+}
+
+#[doc(hidden)]
+pub fn fmt_diff(
+    w: &mut dyn Write,
+    mut diff: impl Iterator<Item = (Position, CellDiff)>,
+) -> Result<usize, core::fmt::Error> {
+    let mut count = 0;
+    diff.try_for_each(|(pos, cd)| {
+        count += 1;
+        writeln!(w, "{pos:?} [expected - found]")?;
+        if let Some(fg) = cd.fg {
+            write!(w, "fg [{:?} - {:?}] ", fg.expected, fg.found)?;
+        }
+        if let Some(bg) = cd.bg {
+            write!(w, "bg [{:?} - {:?}] ", bg.expected, bg.found)?;
+        }
+        if let Some(ch) = cd.ch {
+            write!(w, "ch [{:?} - {:?}]", ch.expected, ch.found)?;
+        }
+
+        writeln!(w)
+    })?;
+
+    Ok(count)
+}
+
+#[macro_export]
+macro_rules! buf_assert_eq {
+    ($lhs:expr, $rhs:expr, $msg:expr) => {{
+        let lhs = $lhs;
+        let rhs = $rhs;
+
+        let mut s = String::new();
+        let count = $crate::core::buffer::test::fmt_diff(&mut s, $crate::core::buffer::utils::buf_cmp(&lhs, &rhs)).unwrap();
+        if count != 0 {
+            panic!("Buffer assertion failed\n{}", s)
+        }
+    }};
 }

--- a/germterm/src/core/buffer/utils.rs
+++ b/germterm/src/core/buffer/utils.rs
@@ -1,36 +1,8 @@
-use std::io::Write;
-
 use super::Buffer;
 use crate::{color::Color, core::Position};
 
-/// Dumps the contents of a buffer using a writer.
-///
-/// Each row is separated by a newline. Only the character of each cell is included.
-pub fn dump_buffer(buffer: &dyn Buffer, writer: &mut dyn Write) -> std::io::Result<()> {
-    let size = buffer.size();
-    for y in 0..size.height {
-        for x in 0..size.width {
-            let cell = buffer.get_cell(Position::new(x, y));
-            writer.write_all(cell.as_str().as_bytes())?;
-        }
-        if y < size.height - 1 {
-            writer.write_all(b"\n")?;
-        }
-    }
-    Ok(())
-}
-
-/// Dumps the contents of a buffer to a string.
-///
-/// Preallocates the estimated capacity for better performance.
-pub fn dump_buffer_to_string(buffer: &dyn Buffer) -> String {
-    let size = buffer.size();
-    let mut result = Vec::with_capacity((size.width as usize + 1) * size.height as usize);
-    let _ = dump_buffer(buffer, &mut result);
-    String::from_utf8(result).unwrap_or_default()
-}
-
 #[doc(hidden)]
+#[track_caller]
 pub fn buf_cmp(lhs: &dyn Buffer, rhs: &dyn Buffer) -> impl Iterator<Item = (Position, CellDiff)> {
     assert_eq!(lhs.size(), rhs.size());
 
@@ -82,52 +54,4 @@ pub struct CellDiff {
     pub fg: Option<DiffItem<Option<Color>>>,
     pub bg: Option<DiffItem<Option<Color>>>,
     pub ch: Option<DiffItem<Box<str>>>,
-}
-
-#[macro_export]
-macro_rules! buf_str {
-    ($($line:literal),+ $(,)?) => {
-        {
-            use $crate::bbq_inner as b;
-            b!($($line)+)
-        }
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! bbq_inner {
-    ($single:literal) => {{$single}};
-    ($first:literal $($rest:tt)*) => {{
-        #[allow(unused)]
-        use ::core::{concat as c, assert as a};
-        #[allow(unused)]
-        const L: usize = $first.len();
-        b!([$first, "\n"] $($rest)*)
-    }};
-    ([$($loaded:literal),+] $next:literal $($rest:tt)+) => {{
-        const _: () = a!(L == $next.len());
-        b!([$($loaded),+, $next, "\n"] $($rest)+)
-    }};
-    ([$($loaded:literal),+] $last:literal) => {
-        c!($($loaded),+, $last)
-    };
-}
-
-// TODO: use trybuild for testing different length strings failing
-#[cfg(test)]
-mod tests {
-    #[rustfmt::skip]
-    const FOUND: &str = crate::buf_str!(
-        "1234567", 
-        "ABCDEFG", 
-        "!@#$%^&",
-    );
-
-    const EXPECTED: &str = "1234567\nABCDEFG\n!@#$%^&";
-
-    #[test]
-    fn buffer_literal_formats_correctly() {
-        assert_eq!(FOUND, EXPECTED);
-    }
 }

--- a/germterm/src/core/buffer/utils.rs
+++ b/germterm/src/core/buffer/utils.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use super::Buffer;
-use crate::core::Position;
+use crate::{color::Color, core::Position};
 
 /// Dumps the contents of a buffer using a writer.
 ///
@@ -11,9 +11,7 @@ pub fn dump_buffer(buffer: &dyn Buffer, writer: &mut dyn Write) -> std::io::Resu
     for y in 0..size.height {
         for x in 0..size.width {
             let cell = buffer.get_cell(Position::new(x, y));
-            let mut buf = [0u8; 4];
-            let s = cell.ch.encode_utf8(&mut buf);
-            writer.write_all(s.as_bytes())?;
+            writer.write_all(cell.as_str().as_bytes())?;
         }
         if y < size.height - 1 {
             writer.write_all(b"\n")?;
@@ -30,6 +28,60 @@ pub fn dump_buffer_to_string(buffer: &dyn Buffer) -> String {
     let mut result = Vec::with_capacity((size.width as usize + 1) * size.height as usize);
     let _ = dump_buffer(buffer, &mut result);
     String::from_utf8(result).unwrap_or_default()
+}
+
+#[doc(hidden)]
+pub fn buf_cmp(lhs: &dyn Buffer, rhs: &dyn Buffer) -> impl Iterator<Item = (Position, CellDiff)> {
+    assert_eq!(lhs.size(), rhs.size());
+
+    let sz = lhs.size();
+    (0..sz.height).flat_map(move |y| {
+        (0..sz.width).filter_map(move |x| {
+            let pos = Position { x, y };
+            let lhs_cell = lhs.get_cell(pos);
+            let lhs_style = lhs_cell.style();
+            let rhs_cell = rhs.get_cell(pos);
+            let rhs_style = lhs_cell.style();
+
+            fn cmp_ret<T: Eq>(lhs: T, rhs: T) -> Option<DiffItem<T>> {
+                if lhs != rhs {
+                    Some(DiffItem {
+                        expected: lhs,
+                        found: rhs,
+                    })
+                } else {
+                    None
+                }
+            }
+
+            let cd = CellDiff {
+                fg: cmp_ret(lhs_style.fg(), rhs_style.fg()),
+                bg: cmp_ret(lhs_style.bg(), rhs_style.bg()),
+                ch: cmp_ret(lhs_cell.as_str().into(), rhs_cell.as_str().into()),
+            };
+
+            if cd == CellDiff::default() {
+                None
+            } else {
+                Some((pos, cd))
+            }
+        })
+    })
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DiffItem<T> {
+    pub expected: T,
+    pub found: T,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CellDiff {
+    pub fg: Option<DiffItem<Option<Color>>>,
+    pub bg: Option<DiffItem<Option<Color>>>,
+    pub ch: Option<DiffItem<Box<str>>>,
 }
 
 #[macro_export]

--- a/germterm/src/core/draw/gfx/normal.rs
+++ b/germterm/src/core/draw/gfx/normal.rs
@@ -26,7 +26,7 @@ pub fn draw_vline<Buf: Buffer>(buf: &mut Buf, start: Position, len: u16, cell: C
     let to_render = renderable.min(len);
     for y in start.y..start.y + to_render {
         let cur = buf.get_cell_mut(Position::new(start.x, y));
-        cur.merge(cell);
+        cur.merge(&cell);
     }
 
     to_render
@@ -51,7 +51,7 @@ pub fn draw_hline<Buf: Buffer>(buf: &mut Buf, start: Position, len: u16, cell: C
     let to_render = renderable.min(len);
     for x in start.x..start.x + to_render {
         let cur = buf.get_cell_mut(Position::new(x, start.y));
-        cur.merge(cell);
+        cur.merge(&cell);
     }
 
     to_render
@@ -133,7 +133,7 @@ pub fn draw_line<Buf: Buffer>(buf: &mut Buf, start: Position, end: Position, cel
 
     // Draw
     for i in 0..=steps {
-        buf.get_cell_mut(cell_pos(x, y)).merge(cell);
+        buf.get_cell_mut(cell_pos(x, y)).merge(&cell);
 
         error += step_inc;
         if error >= 0 {
@@ -172,7 +172,7 @@ pub fn draw_style<Buf: Buffer>(buf: &mut Buf, area: Rect, style: Style) -> u32 {
 
     for y in 0..sz.height {
         for x in 0..sz.width {
-            sub.get_cell_mut(Position { x, y }).style.merge(style);
+            sub.get_cell_mut(Position { x, y }).style_mut().merge(style);
         }
     }
 
@@ -191,10 +191,7 @@ mod tests {
     };
 
     fn test_cell() -> Cell {
-        Cell {
-            ch: '#',
-            ..Cell::EMPTY
-        }
+        Cell::new("", Style::EMPTY)
     }
 
     fn make_buf(sz: Size) -> FlatBuffer {

--- a/germterm/src/core/draw/gfx/normal.rs
+++ b/germterm/src/core/draw/gfx/normal.rs
@@ -183,15 +183,12 @@ pub fn draw_style<Buf: Buffer>(buf: &mut Buf, area: Rect, style: Style) -> u32 {
 mod tests {
     use super::*;
     use crate::{
-        buf_str,
-        core::{
-            buffer::{flat::FlatBuffer, utils::dump_buffer_to_string as dbts},
-            draw::Size,
-        },
+        buf_assert_eq, buffer,
+        core::{buffer::flat::FlatBuffer, draw::Size},
     };
 
     fn test_cell() -> Cell {
-        Cell::new("", Style::EMPTY)
+        Cell::new("#", Style::EMPTY)
     }
 
     fn make_buf(sz: Size) -> FlatBuffer {
@@ -205,19 +202,19 @@ mod tests {
         let written = draw_vline(&mut buf, Position::ZERO, len, test_cell());
         assert_eq!(written, len);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str![
-                "#         ",
-                "#         ",
-                "#         ",
-                "#         ",
-                "#         ",
-                "#         ",
-                "#         ",
-                "#         ",
-                "#         ",
-                "#         ",
+        buf_assert_eq!(
+            buf,
+            buffer![
+                ["#", empty(9)],
+                ["#", empty(9)],
+                ["#", empty(9)],
+                ["#", empty(9)],
+                ["#", empty(9)],
+                ["#", empty(9)],
+                ["#", empty(9)],
+                ["#", empty(9)],
+                ["#", empty(9)],
+                ["#", empty(9)],
             ]
         );
     }
@@ -230,19 +227,16 @@ mod tests {
         let written = draw_vline(&mut buf, start, len, test_cell());
         assert_eq!(written, len);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str![
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "    #     ",
-                "    #     ",
-                "    #     ",
-                "    #     ",
-                "    #     ",
-                "    #     ",
+        buf_assert_eq!(
+            buf,
+            buffer![
+                empty(4),
+                [empty(4), "#", empty(5)],
+                [empty(4), "#", empty(5)],
+                [empty(4), "#", empty(5)],
+                [empty(4), "#", empty(5)],
+                [empty(4), "#", empty(5)],
+                [empty(4), "#", empty(5)],
             ]
         );
     }
@@ -253,20 +247,14 @@ mod tests {
         let written = draw_vline(&mut buf, Position::new(4, 7), 10, test_cell());
         assert_eq!(written, 3);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str![
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "    #     ",
-                "    #     ",
-                "    #     ",
-            ],
+        buf_assert_eq!(
+            buf,
+            buffer![
+                empty(7),
+                [empty(4), "#", empty(5)],
+                [empty(4), "#", empty(5)],
+                [empty(4), "#", empty(5)],
+            ]
         );
     }
 
@@ -276,20 +264,13 @@ mod tests {
         let written = draw_vline(&mut buf, Position::new(4, 8), 5, test_cell());
         assert_eq!(written, 2);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str![
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "    #     ",
-                "    #     ",
-            ],
+        buf_assert_eq!(
+            buf,
+            buffer![
+                empty(8),
+                [empty(4), "#", empty(5)],
+                [empty(4), "#", empty(5)],
+            ]
         );
     }
 
@@ -300,20 +281,9 @@ mod tests {
         let written = draw_hline(&mut buf, Position::ZERO, len, test_cell());
         assert_eq!(written, len);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str![
-                "##########",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-            ],
+        buf_assert_eq!(
+            buf,
+            buffer![["#", "#", "#", "#", "#", "#", "#", "#", "#", "#"], empty(9),]
         );
     }
 
@@ -324,20 +294,9 @@ mod tests {
         let written = draw_hline(&mut buf, Position::new(2, 2), len, test_cell());
         assert_eq!(written, len);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str![
-                "          ",
-                "          ",
-                "  ####    ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-            ],
+        buf_assert_eq!(
+            buf,
+            buffer![empty(2), [empty(2), "#", "#", "#", "#", empty(4)], empty(7),]
         );
     }
 
@@ -347,21 +306,7 @@ mod tests {
         let written = draw_hline(&mut buf, Position::new(7, 4), 10, test_cell());
         assert_eq!(written, 3);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str![
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "       ###",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-            ],
-        );
+        buf_assert_eq!(buf, buffer![empty(4), [empty(7), "#", "#", "#"], empty(5),]);
     }
 
     #[test]
@@ -370,21 +315,7 @@ mod tests {
         let written = draw_hline(&mut buf, Position::new(15, 4), 5, test_cell());
         assert_eq!(written, 0);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str![
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-            ],
-        );
+        buf_assert_eq!(buf, buffer![[empty(10)], empty(9)]);
     }
 
     #[test]
@@ -399,20 +330,20 @@ mod tests {
 
         assert_eq!(drawn, 10);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str![
-                "#         ",
-                " #        ",
-                "  #       ",
-                "   #      ",
-                "    #     ",
-                "     #    ",
-                "      #   ",
-                "       #  ",
-                "        # ",
-                "         #",
-            ],
+        buf_assert_eq!(
+            buf,
+            buffer![
+                ["#", empty(9)],
+                [empty(1), "#", empty(8)],
+                [empty(2), "#", empty(7)],
+                [empty(3), "#", empty(6)],
+                [empty(4), "#", empty(5)],
+                [empty(5), "#", empty(4)],
+                [empty(6), "#", empty(3)],
+                [empty(7), "#", empty(2)],
+                [empty(8), "#", empty(1)],
+                [empty(9), "#"],
+            ]
         );
     }
 
@@ -428,20 +359,20 @@ mod tests {
 
         assert_eq!(drawn, 7);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str![
-                "          ",
-                "  #       ",
-                "   #      ",
-                "   #      ",
-                "    #     ",
-                "    #     ",
-                "     #    ",
-                "     #    ",
-                "          ",
-                "          ",
-            ],
+        buf_assert_eq!(
+            buf,
+            buffer![
+                [empty(10)],
+                [empty(2), "#", empty(7)],
+                [empty(3), "#", empty(6)],
+                [empty(3), "#", empty(6)],
+                [empty(4), "#", empty(5)],
+                [empty(4), "#", empty(5)],
+                [empty(5), "#", empty(4)],
+                [empty(5), "#", empty(4)],
+                [empty(10)],
+                [empty(10)],
+            ]
         );
     }
 
@@ -457,20 +388,20 @@ mod tests {
 
         assert_eq!(drawn, 7);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str![
-                "          ",
-                "  #       ",
-                "   #      ",
-                "   #      ",
-                "    #     ",
-                "    #     ",
-                "     #    ",
-                "     #    ",
-                "          ",
-                "          ",
-            ],
+        buf_assert_eq!(
+            buf,
+            buffer![
+                [empty(10)],
+                [empty(2), "#", empty(7)],
+                [empty(3), "#", empty(6)],
+                [empty(3), "#", empty(6)],
+                [empty(4), "#", empty(5)],
+                [empty(4), "#", empty(5)],
+                [empty(5), "#", empty(4)],
+                [empty(5), "#", empty(4)],
+                [empty(10)],
+                [empty(10)],
+            ]
         );
     }
 
@@ -486,20 +417,18 @@ mod tests {
 
         assert_eq!(drawn, 7);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str![
-                "          ",
-                "          ",
-                "          ",
-                " #        ",
-                " #        ",
-                "  #       ",
-                "  #       ",
-                "   #      ",
-                "   #      ",
-                "    #     ",
-            ],
+        buf_assert_eq!(
+            buf,
+            buffer![
+                empty(3),
+                [empty(1), "#", empty(8)],
+                [empty(1), "#", empty(8)],
+                [empty(2), "#", empty(7)],
+                [empty(2), "#", empty(7)],
+                [empty(3), "#", empty(6)],
+                [empty(3), "#", empty(6)],
+                [empty(4), "#", empty(5)],
+            ]
         );
     }
 
@@ -515,20 +444,14 @@ mod tests {
 
         assert_eq!(drawn, 5);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str![
-                "          ",
-                "          ",
-                "     #### ",
-                "         #",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-                "          ",
-            ],
+        buf_assert_eq!(
+            buf,
+            buffer![
+                empty(2),
+                [empty(5), "#", "#", "#", "#", empty(1)],
+                [empty(9), "#"],
+                empty(6),
+            ]
         );
     }
 
@@ -544,20 +467,18 @@ mod tests {
 
         assert_eq!(drawn, 7);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str![
-                "          ",
-                "          ",
-                "          ",
-                "        # ",
-                "       #  ",
-                "       #  ",
-                "      #   ",
-                "      #   ",
-                "     #    ",
-                "     #    ",
-            ],
+        buf_assert_eq!(
+            buf,
+            buffer![
+                empty(3),
+                [empty(8), "#", empty(1)],
+                [empty(7), "#", empty(2)],
+                [empty(7), "#", empty(2)],
+                [empty(6), "#", empty(3)],
+                [empty(6), "#", empty(3)],
+                [empty(5), "#", empty(4)],
+                [empty(5), "#", empty(4)],
+            ]
         );
     }
 }

--- a/germterm/src/core/draw/gfx/normal.rs
+++ b/germterm/src/core/draw/gfx/normal.rs
@@ -16,7 +16,7 @@ use crate::{
 /// # Returns
 ///
 /// The number of cells written.
-pub fn draw_vline<Buf: Buffer>(buf: &mut Buf, start: Position, len: u16, cell: Cell) -> u16 {
+pub fn draw_vline<Buf: Buffer>(buf: &mut Buf, start: Position, len: u16, cell: &Cell) -> u16 {
     let sz = buf.size();
     if !sz.is_within(start) {
         return 0;
@@ -26,7 +26,7 @@ pub fn draw_vline<Buf: Buffer>(buf: &mut Buf, start: Position, len: u16, cell: C
     let to_render = renderable.min(len);
     for y in start.y..start.y + to_render {
         let cur = buf.get_cell_mut(Position::new(start.x, y));
-        cur.merge(&cell);
+        cur.merge(cell);
     }
 
     to_render
@@ -41,7 +41,7 @@ pub fn draw_vline<Buf: Buffer>(buf: &mut Buf, start: Position, len: u16, cell: C
 /// # Returns
 ///
 /// The number of cells written.
-pub fn draw_hline<Buf: Buffer>(buf: &mut Buf, start: Position, len: u16, cell: Cell) -> u16 {
+pub fn draw_hline<Buf: Buffer>(buf: &mut Buf, start: Position, len: u16, cell: &Cell) -> u16 {
     let sz = buf.size();
     if !sz.is_within(start) {
         return 0;
@@ -51,7 +51,7 @@ pub fn draw_hline<Buf: Buffer>(buf: &mut Buf, start: Position, len: u16, cell: C
     let to_render = renderable.min(len);
     for x in start.x..start.x + to_render {
         let cur = buf.get_cell_mut(Position::new(x, start.y));
-        cur.merge(&cell);
+        cur.merge(cell);
     }
 
     to_render
@@ -74,7 +74,7 @@ pub fn draw_hline<Buf: Buffer>(buf: &mut Buf, start: Position, len: u16, cell: C
 /// # Returns
 ///
 /// The number of cells written.
-pub fn draw_line<Buf: Buffer>(buf: &mut Buf, start: Position, end: Position, cell: Cell) -> u32 {
+pub fn draw_line<Buf: Buffer>(buf: &mut Buf, start: Position, end: Position, cell: &Cell) -> u32 {
     let sz = buf.size();
     if sz.area() == 0 {
         return 0;
@@ -133,7 +133,7 @@ pub fn draw_line<Buf: Buffer>(buf: &mut Buf, start: Position, end: Position, cel
 
     // Draw
     for i in 0..=steps {
-        buf.get_cell_mut(cell_pos(x, y)).merge(&cell);
+        buf.get_cell_mut(cell_pos(x, y)).merge(cell);
 
         error += step_inc;
         if error >= 0 {
@@ -199,7 +199,7 @@ mod tests {
     fn vertical_line() {
         let mut buf = make_buf(Size::new(10, 10));
         let len = 10;
-        let written = draw_vline(&mut buf, Position::ZERO, len, test_cell());
+        let written = draw_vline(&mut buf, Position::ZERO, len, &test_cell());
         assert_eq!(written, len);
 
         buf_assert_eq!(
@@ -224,7 +224,7 @@ mod tests {
         let mut buf = make_buf(Size::new(10, 10));
         let len = 6;
         let start = Position::new(4, 4);
-        let written = draw_vline(&mut buf, start, len, test_cell());
+        let written = draw_vline(&mut buf, start, len, &test_cell());
         assert_eq!(written, len);
 
         buf_assert_eq!(
@@ -244,7 +244,7 @@ mod tests {
     #[test]
     fn vertical_line_truncated_bottom() {
         let mut buf = make_buf(Size::new(10, 10));
-        let written = draw_vline(&mut buf, Position::new(4, 7), 10, test_cell());
+        let written = draw_vline(&mut buf, Position::new(4, 7), 10, &test_cell());
         assert_eq!(written, 3);
 
         buf_assert_eq!(
@@ -261,7 +261,7 @@ mod tests {
     #[test]
     fn vertical_line_truncated_top() {
         let mut buf = make_buf(Size::new(10, 10));
-        let written = draw_vline(&mut buf, Position::new(4, 8), 5, test_cell());
+        let written = draw_vline(&mut buf, Position::new(4, 8), 5, &test_cell());
         assert_eq!(written, 2);
 
         buf_assert_eq!(
@@ -278,7 +278,7 @@ mod tests {
     fn horizontal_line() {
         let mut buf = make_buf(Size::new(10, 10));
         let len = 10;
-        let written = draw_hline(&mut buf, Position::ZERO, len, test_cell());
+        let written = draw_hline(&mut buf, Position::ZERO, len, &test_cell());
         assert_eq!(written, len);
 
         buf_assert_eq!(
@@ -291,7 +291,7 @@ mod tests {
     fn horizontal_line_partial() {
         let mut buf = make_buf(Size::new(10, 10));
         let len = 4;
-        let written = draw_hline(&mut buf, Position::new(2, 2), len, test_cell());
+        let written = draw_hline(&mut buf, Position::new(2, 2), len, &test_cell());
         assert_eq!(written, len);
 
         buf_assert_eq!(
@@ -303,7 +303,7 @@ mod tests {
     #[test]
     fn horizontal_line_truncated_right() {
         let mut buf = make_buf(Size::new(10, 10));
-        let written = draw_hline(&mut buf, Position::new(7, 4), 10, test_cell());
+        let written = draw_hline(&mut buf, Position::new(7, 4), 10, &test_cell());
         assert_eq!(written, 3);
 
         buf_assert_eq!(buf, buffer![empty(4), [empty(7), "#", "#", "#"], empty(5),]);
@@ -312,7 +312,7 @@ mod tests {
     #[test]
     fn horizontal_line_truncated_left() {
         let mut buf = make_buf(Size::new(10, 10));
-        let written = draw_hline(&mut buf, Position::new(15, 4), 5, test_cell());
+        let written = draw_hline(&mut buf, Position::new(15, 4), 5, &test_cell());
         assert_eq!(written, 0);
 
         buf_assert_eq!(buf, buffer![[empty(10)], empty(9)]);
@@ -325,7 +325,7 @@ mod tests {
             &mut buf,
             Position::new(0, 0),
             Position::new(9, 9),
-            test_cell(),
+            &test_cell(),
         );
 
         assert_eq!(drawn, 10);
@@ -354,7 +354,7 @@ mod tests {
             &mut buf,
             Position::new(2, 1),
             Position::new(5, 7),
-            test_cell(),
+            &test_cell(),
         );
 
         assert_eq!(drawn, 7);
@@ -383,7 +383,7 @@ mod tests {
             &mut buf,
             Position::new(5, 7),
             Position::new(2, 1),
-            test_cell(),
+            &test_cell(),
         );
 
         assert_eq!(drawn, 7);
@@ -412,7 +412,7 @@ mod tests {
             &mut buf,
             Position::new(1, 3),
             Position::new(6, 15),
-            test_cell(),
+            &test_cell(),
         );
 
         assert_eq!(drawn, 7);
@@ -439,7 +439,7 @@ mod tests {
             &mut buf,
             Position::new(5, 2),
             Position::new(20, 5),
-            test_cell(),
+            &test_cell(),
         );
 
         assert_eq!(drawn, 5);
@@ -462,7 +462,7 @@ mod tests {
             &mut buf,
             Position::new(8, 3),
             Position::new(2, 15),
-            test_cell(),
+            &test_cell(),
         );
 
         assert_eq!(drawn, 7);

--- a/germterm/src/core/draw/gfx/text.rs
+++ b/germterm/src/core/draw/gfx/text.rs
@@ -1,6 +1,15 @@
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::core::{buffer::Buffer, draw::Position, widget::FrameContext};
+use crate::{
+    core::{buffer::Buffer, draw::Position, widget::FrameContext},
+    style::Style,
+};
+
+#[derive(Clone, Copy, Debug, Hash, Default, PartialEq, Eq)]
+pub struct WrittenTracker {
+    pub cells: u16,
+    pub bytes: u16,
+}
 
 /// Draw the provided string starting at the specified position.
 ///
@@ -13,13 +22,45 @@ use crate::core::{buffer::Buffer, draw::Position, widget::FrameContext};
 /// Returns the number of cells now occupied that were written.
 pub fn draw_string<Buf: Buffer, D>(
     fc: FrameContext<'_, Buf, D>,
+    pos: Position,
+    s: &str,
+) -> WrittenTracker {
+    draw_text_inline(fc, pos, s, None, u16::MAX)
+}
+
+/// Draw styled text starting at the specified position.
+///
+/// The provided text is written as much as possible in a single line of the buffer.
+/// If the size exceeded the string is truncated. If the string is too short the remaining cells
+/// will stay untouched.
+///
+/// # Returns
+///
+/// Returns the number of cells now occupied that were written.
+pub fn draw_text<Buf: Buffer, D>(
+    fc: FrameContext<'_, Buf, D>,
+    pos: Position,
+    s: &str,
+    style: Style,
+    limit: u16,
+) -> WrittenTracker {
+    draw_text_inline(fc, pos, s, Some(style), limit)
+}
+
+#[inline(always)]
+pub fn draw_text_inline<Buf: Buffer, D>(
+    fc: FrameContext<'_, Buf, D>,
     mut pos: Position,
     s: &str,
-) -> u16 {
+    style: Option<Style>,
+    limit: u16,
+) -> WrittenTracker {
     let sz = fc.buffer.size();
     if sz.area() == 0 || !sz.is_within(pos) {
-        return 0;
+        return WrittenTracker::default();
     }
+
+    let mut wt = WrittenTracker::default();
 
     let orig = pos.x;
     for g in s.graphemes(true) {
@@ -27,15 +68,22 @@ pub fn draw_string<Buf: Buffer, D>(
         let Some(added) = pos
             .x
             .checked_add(grapheme_width)
-            .filter(|added| sz.width >= *added)
+            .filter(|added| sz.width >= *added || limit < *added)
         else {
             break;
         };
-        fc.buffer.get_cell_mut(pos).set_str(g);
+
+        let cell = fc.buffer.get_cell_mut(pos);
+        cell.set_str(g);
+        if let Some(style) = style {
+            cell.style_mut().merge(style);
+        }
+        wt.bytes += g.len() as u16;
         pos.x = added;
     }
 
-    pos.x - orig
+    wt.cells = pos.x - orig;
+    wt
 }
 
 #[cfg(test)]
@@ -58,28 +106,28 @@ mod tests {
     fn zero_area_buffer_returns_zero() {
         let mut buf = make_buf(Size::ZERO);
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello");
-        assert_eq!(written, 0);
+        assert_eq!(written, WrittenTracker::default());
     }
 
     #[test]
     fn zero_width_buffer_returns_zero() {
         let mut buf = make_buf(Size::new(0, 5));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello");
-        assert_eq!(written, 0);
+        assert_eq!(written, WrittenTracker::default());
     }
 
     #[test]
     fn zero_height_buffer_returns_zero() {
         let mut buf = make_buf(Size::new(5, 0));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello");
-        assert_eq!(written, 0);
+        assert_eq!(written, WrittenTracker::default());
     }
 
     #[test]
     fn start_x_out_of_bounds_returns_zero() {
         let mut buf = make_buf(Size::new(5, 3));
         let written = draw_string(make_fc(&mut buf), Position::new(5, 0), "hello");
-        assert_eq!(written, 0);
+        assert_eq!(written, WrittenTracker::default());
 
         buf_assert_eq!(buf, buffer![[empty(5)], empty(2)]);
     }
@@ -88,7 +136,7 @@ mod tests {
     fn start_y_out_of_bounds_returns_zero() {
         let mut buf = make_buf(Size::new(5, 3));
         let written = draw_string(make_fc(&mut buf), Position::new(0, 3), "hello");
-        assert_eq!(written, 0);
+        assert_eq!(written, WrittenTracker::default());
 
         buf_assert_eq!(buf, buffer![empty(2), [empty(5)]]);
     }
@@ -97,7 +145,7 @@ mod tests {
     fn empty_string_returns_zero() {
         let mut buf = make_buf(Size::new(5, 3));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "");
-        assert_eq!(written, 0);
+        assert_eq!(written, WrittenTracker::default());
 
         buf_assert_eq!(buf, buffer![[empty(5)], empty(2)]);
     }
@@ -106,7 +154,7 @@ mod tests {
     fn string_fits_entirely() {
         let mut buf = make_buf(Size::new(10, 3));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello");
-        assert_eq!(written, 5);
+        assert_eq!(written, WrittenTracker { cells: 5, bytes: 5 });
 
         buf_assert_eq!(buf, buffer![["h", "e", "l", "l", "o", empty(5)], empty(2)]);
     }
@@ -115,7 +163,7 @@ mod tests {
     fn string_truncated_at_right_edge() {
         let mut buf = make_buf(Size::new(5, 3));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello world");
-        assert_eq!(written, 5);
+        assert_eq!(written, WrittenTracker { cells: 5, bytes: 5 });
 
         buf_assert_eq!(buf, buffer![["h", "e", "l", "l", "o"], empty(2)]);
     }
@@ -124,7 +172,7 @@ mod tests {
     fn string_exactly_fills_width() {
         let mut buf = make_buf(Size::new(5, 2));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "abcde");
-        assert_eq!(written, 5);
+        assert_eq!(written, WrittenTracker { cells: 5, bytes: 5 });
 
         buf_assert_eq!(buf, buffer![["a", "b", "c", "d", "e"], empty(1)]);
     }
@@ -133,7 +181,7 @@ mod tests {
     fn start_at_nonzero_x() {
         let mut buf = make_buf(Size::new(10, 3));
         let written = draw_string(make_fc(&mut buf), Position::new(4, 0), "hello");
-        assert_eq!(written, 5);
+        assert_eq!(written, WrittenTracker { cells: 5, bytes: 5 });
 
         buf_assert_eq!(
             buf,
@@ -145,7 +193,7 @@ mod tests {
     fn start_at_nonzero_y() {
         let mut buf = make_buf(Size::new(10, 3));
         let written = draw_string(make_fc(&mut buf), Position::new(0, 2), "hello");
-        assert_eq!(written, 5);
+        assert_eq!(written, WrittenTracker { cells: 5, bytes: 5 });
 
         buf_assert_eq!(buf, buffer![empty(2), ["h", "e", "l", "l", "o", empty(5)],]);
     }
@@ -154,7 +202,7 @@ mod tests {
     fn start_at_nonzero_x_and_y() {
         let mut buf = make_buf(Size::new(10, 3));
         let written = draw_string(make_fc(&mut buf), Position::new(3, 1), "test");
-        assert_eq!(written, 4);
+        assert_eq!(written, WrittenTracker { cells: 4, bytes: 4 });
 
         buf_assert_eq!(
             buf,
@@ -170,7 +218,7 @@ mod tests {
     fn start_at_nonzero_x_truncated() {
         let mut buf = make_buf(Size::new(8, 2));
         let written = draw_string(make_fc(&mut buf), Position::new(5, 0), "hello");
-        assert_eq!(written, 3);
+        assert_eq!(written, WrittenTracker { cells: 3, bytes: 3 });
 
         buf_assert_eq!(buf, buffer![[empty(5), "h", "e", "l"], empty(1),]);
     }
@@ -179,7 +227,7 @@ mod tests {
     fn single_cell_buffer() {
         let mut buf = make_buf(Size::new(1, 1));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello");
-        assert_eq!(written, 1);
+        assert_eq!(written, WrittenTracker { cells: 1, bytes: 1 });
 
         buf_assert_eq!(buf, buffer![["h"]]);
     }
@@ -188,7 +236,7 @@ mod tests {
     fn single_char_string() {
         let mut buf = make_buf(Size::new(5, 2));
         let written = draw_string(make_fc(&mut buf), Position::new(2, 0), "x");
-        assert_eq!(written, 1);
+        assert_eq!(written, WrittenTracker { cells: 1, bytes: 1 });
 
         buf_assert_eq!(buf, buffer![[empty(2), "x", empty(2)], empty(1)])
     }
@@ -197,7 +245,7 @@ mod tests {
     fn emoji_takes_two_cells() {
         let mut buf = make_buf(Size::new(5, 2));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "😀");
-        assert_eq!(written, 2);
+        assert_eq!(written, WrittenTracker { cells: 2, bytes: 4 });
 
         buf_assert_eq!(buf, buffer![["😀", empty(4)], [empty(5)]]);
     }
@@ -206,7 +254,7 @@ mod tests {
     fn multiple_emoji() {
         let mut buf = make_buf(Size::new(6, 2));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "😀😎");
-        assert_eq!(written, 4);
+        assert_eq!(written, WrittenTracker { cells: 4, bytes: 8 });
 
         buf_assert_eq!(
             buf,
@@ -218,7 +266,7 @@ mod tests {
     fn emoji_truncated() {
         let mut buf = make_buf(Size::new(3, 2));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "😀😀😀");
-        assert_eq!(written, 2);
+        assert_eq!(written, WrittenTracker { cells: 2, bytes: 4 });
 
         buf_assert_eq!(buf, buffer![["😀", empty(2)], empty(1)]);
     }
@@ -227,7 +275,7 @@ mod tests {
     fn emoji_doesnt_fit_single_cell() {
         let mut buf = make_buf(Size::new(1, 2));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "😀");
-        assert_eq!(written, 0);
+        assert_eq!(written, WrittenTracker::default());
 
         buf_assert_eq!(buf, buffer![empty(1), [" "]]);
     }
@@ -236,7 +284,7 @@ mod tests {
     fn cjk_char_takes_two_cells() {
         let mut buf = make_buf(Size::new(5, 2));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "中");
-        assert_eq!(written, 2);
+        assert_eq!(written, WrittenTracker { cells: 2, bytes: 3 });
 
         buf_assert_eq!(buf, buffer![["中", empty(4)], empty(1)]);
     }
@@ -245,7 +293,7 @@ mod tests {
     fn cjk_mixed_with_ascii() {
         let mut buf = make_buf(Size::new(10, 2));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "中文abc");
-        assert_eq!(written, 7);
+        assert_eq!(written, WrittenTracker { cells: 7, bytes: 9 });
 
         buf_assert_eq!(
             buf,
@@ -260,7 +308,7 @@ mod tests {
     fn cjk_truncated() {
         let mut buf = make_buf(Size::new(3, 2));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "中文");
-        assert_eq!(written, 2);
+        assert_eq!(written, WrittenTracker { cells: 2, bytes: 3 });
 
         buf_assert_eq![buf, buffer![["中", empty(2)], empty(1)]];
     }
@@ -269,7 +317,7 @@ mod tests {
     fn superscript_takes_one_cell() {
         let mut buf = make_buf(Size::new(5, 2));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "x²");
-        assert_eq!(written, 2);
+        assert_eq!(written, WrittenTracker { cells: 2, bytes: 3 });
 
         buf_assert_eq!(buf, buffer![["x", "²", empty(3)], empty(1)]);
     }
@@ -278,7 +326,13 @@ mod tests {
     fn mathematical_symbols() {
         let mut buf = make_buf(Size::new(10, 2));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "x²+y³=z⁴");
-        assert_eq!(written, 8);
+        assert_eq!(
+            written,
+            WrittenTracker {
+                cells: 8,
+                bytes: 12
+            }
+        );
 
         buf_assert_eq!(
             buf,
@@ -291,7 +345,13 @@ mod tests {
         let mut buf = make_buf(Size::new(15, 2));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "Hi中😀文");
 
-        assert_eq!(written, 8);
+        assert_eq!(
+            written,
+            WrittenTracker {
+                cells: 8,
+                bytes: 12
+            }
+        );
         buf_assert_eq!(
             buf,
             buffer!(

--- a/germterm/src/core/draw/gfx/text.rs
+++ b/germterm/src/core/draw/gfx/text.rs
@@ -42,13 +42,8 @@ pub fn draw_string<Buf: Buffer, D>(
 mod tests {
     use super::*;
     use crate::{
-        buf_str,
-        core::{
-            DisplayWidth,
-            buffer::{flat::FlatBuffer, utils::dump_buffer_to_string as dbts},
-            draw::Size,
-            timer::NoDelta,
-        },
+        buf_assert_eq, buffer,
+        core::{DisplayWidth, buffer::flat::FlatBuffer, draw::Size, timer::NoDelta},
     };
 
     fn make_buf(sz: Size) -> FlatBuffer {
@@ -86,7 +81,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::new(5, 0), "hello");
         assert_eq!(written, 0);
 
-        assert_eq!(dbts(&buf), buf_str!["     ", "     ", "     ",]);
+        buf_assert_eq!(buf, buffer![[empty(5)], empty(2)]);
     }
 
     #[test]
@@ -95,7 +90,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::new(0, 3), "hello");
         assert_eq!(written, 0);
 
-        assert_eq!(dbts(&buf), buf_str!["     ", "     ", "     ",]);
+        buf_assert_eq!(buf, buffer![empty(2), [empty(5)]]);
     }
 
     #[test]
@@ -104,7 +99,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "");
         assert_eq!(written, 0);
 
-        assert_eq!(dbts(&buf), buf_str!["     ", "     ", "     ",]);
+        buf_assert_eq!(buf, buffer![[empty(5)], empty(2)]);
     }
 
     #[test]
@@ -113,10 +108,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello");
         assert_eq!(written, 5);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["hello     ", "          ", "          ",]
-        );
+        buf_assert_eq!(buf, buffer![["h", "e", "l", "l", "o", empty(5)], empty(2)]);
     }
 
     #[test]
@@ -125,7 +117,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello world");
         assert_eq!(written, 5);
 
-        assert_eq!(dbts(&buf), buf_str!["hello", "     ", "     ",]);
+        buf_assert_eq!(buf, buffer![["h", "e", "l", "l", "o"], empty(2)]);
     }
 
     #[test]
@@ -134,7 +126,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "abcde");
         assert_eq!(written, 5);
 
-        assert_eq!(dbts(&buf), buf_str!["abcde", "     ",]);
+        buf_assert_eq!(buf, buffer![["a", "b", "c", "d", "e"], empty(1)]);
     }
 
     #[test]
@@ -143,9 +135,9 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::new(4, 0), "hello");
         assert_eq!(written, 5);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["    hello ", "          ", "          ",]
+        buf_assert_eq!(
+            buf,
+            buffer![[empty(4), "h", "e", "l", "l", "o", " "], empty(2)]
         );
     }
 
@@ -155,10 +147,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::new(0, 2), "hello");
         assert_eq!(written, 5);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["          ", "          ", "hello     ",]
-        );
+        buf_assert_eq!(buf, buffer![empty(2), ["h", "e", "l", "l", "o", empty(5)],]);
     }
 
     #[test]
@@ -167,9 +156,13 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::new(3, 1), "test");
         assert_eq!(written, 4);
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["          ", "   test   ", "          ",]
+        buf_assert_eq!(
+            buf,
+            buffer![
+                empty(1),
+                [" ", " ", " ", "t", "e", "s", "t", " ", " ", " "],
+                empty(1)
+            ]
         );
     }
 
@@ -179,7 +172,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::new(5, 0), "hello");
         assert_eq!(written, 3);
 
-        assert_eq!(dbts(&buf), buf_str!["     hel", "        ",]);
+        buf_assert_eq!(buf, buffer![[empty(5), "h", "e", "l"], empty(1),]);
     }
 
     #[test]
@@ -188,7 +181,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello");
         assert_eq!(written, 1);
 
-        assert_eq!(dbts(&buf), buf_str!["h"]);
+        buf_assert_eq!(buf, buffer![["h"]]);
     }
 
     #[test]
@@ -197,7 +190,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::new(2, 0), "x");
         assert_eq!(written, 1);
 
-        assert_eq!(dbts(&buf), buf_str!["  x  ", "     ",]);
+        buf_assert_eq!(buf, buffer![[empty(2), "x", empty(2)], empty(1)])
     }
 
     #[test]
@@ -206,7 +199,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "😀");
         assert_eq!(written, 2);
 
-        assert_eq!(dbts(&buf), buf_str!["😀  ", "     ",]);
+        buf_assert_eq!(buf, buffer![["😀", empty(4)], [empty(5)]]);
     }
 
     #[test]
@@ -215,16 +208,19 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "😀😎");
         assert_eq!(written, 4);
 
-        assert_eq!(dbts(&buf), buf_str!["😀😎  ", "      ",]);
+        buf_assert_eq!(
+            buf,
+            buffer![["😀", empty(1), "😎", empty(1), empty(2)], empty(1)]
+        );
     }
 
     #[test]
     fn emoji_truncated() {
         let mut buf = make_buf(Size::new(3, 2));
-        let written = draw_string(make_fc(&mut buf), Position::ZERO, "😀");
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "😀😀😀");
         assert_eq!(written, 2);
 
-        assert_eq!(dbts(&buf), buf_str!["😀 ", "   ",]);
+        buf_assert_eq!(buf, buffer![["😀", empty(2)], empty(1)]);
     }
 
     #[test]
@@ -233,7 +229,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "😀");
         assert_eq!(written, 0);
 
-        assert_eq!(dbts(&buf), buf_str![" ", " ",]);
+        buf_assert_eq!(buf, buffer![empty(1), [" "]]);
     }
 
     #[test]
@@ -242,7 +238,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "中");
         assert_eq!(written, 2);
 
-        assert_eq!(dbts(&buf), buf_str!["中  ", "     ",]);
+        buf_assert_eq!(buf, buffer![["中", empty(4)], empty(1)]);
     }
 
     #[test]
@@ -251,7 +247,13 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "中文abc");
         assert_eq!(written, 7);
 
-        assert_eq!(dbts(&buf), buf_str!["中文abc   ", "          ",]);
+        buf_assert_eq!(
+            buf,
+            buffer![
+                ["中", empty(1), "文", empty(1), "a", "b", "c", empty(3)],
+                empty(1)
+            ]
+        );
     }
 
     #[test]
@@ -260,7 +262,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "中文");
         assert_eq!(written, 2);
 
-        assert_eq!(dbts(&buf), buf_str!["中 ", "   ",]);
+        buf_assert_eq![buf, buffer![["中", empty(2)], empty(1)]];
     }
 
     #[test]
@@ -269,7 +271,7 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "x²");
         assert_eq!(written, 2);
 
-        assert_eq!(dbts(&buf), buf_str!["x²  ", "     ",]);
+        buf_assert_eq!(buf, buffer![["x", "²", empty(3)], empty(1)]);
     }
 
     #[test]
@@ -278,7 +280,10 @@ mod tests {
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "x²+y³=z⁴");
         assert_eq!(written, 8);
 
-        assert_eq!(dbts(&buf), buf_str!["x²+y³=z⁴  ", "          ",]);
+        buf_assert_eq!(
+            buf,
+            buffer![["x", "²", "+", "y", "³", "=", "z", "⁴", empty(2)], empty(1)]
+        );
     }
 
     #[test]
@@ -286,6 +291,13 @@ mod tests {
         let mut buf = make_buf(Size::new(15, 2));
         let written = draw_string(make_fc(&mut buf), Position::ZERO, "Hi中😀文");
 
-        assert_eq!(dbts(&buf), buf_str!["Hi中😀文   ", "               ",]);
+        assert_eq!(written, 8);
+        buf_assert_eq!(
+            buf,
+            buffer!(
+                ["H", "i", "中", empty(1), "😀", empty(1), "文", empty(8)],
+                [empty(15)]
+            )
+        )
     }
 }

--- a/germterm/src/core/draw/gfx/text.rs
+++ b/germterm/src/core/draw/gfx/text.rs
@@ -1,4 +1,6 @@
-use crate::core::{buffer::Buffer, draw::Position};
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::core::{buffer::Buffer, draw::Position, widget::FrameContext};
 
 /// Draw the provided string starting at the specified position.
 ///
@@ -8,21 +10,32 @@ use crate::core::{buffer::Buffer, draw::Position};
 ///
 /// # Returns
 ///
-/// Returns the number of characters that were written.
-pub fn draw_string<Buf: Buffer>(buf: &mut Buf, start: Position, s: &str) -> u16 {
-    let sz = buf.size();
-    if sz.area() == 0 || !sz.is_within(start) {
+/// Returns the number of cells now occupied that were written.
+pub fn draw_string<Buf: Buffer, D>(
+    fc: FrameContext<'_, Buf, D>,
+    mut pos: Position,
+    s: &str,
+) -> u16 {
+    let sz = fc.buffer.size();
+    if sz.area() == 0 || !sz.is_within(pos) {
         return 0;
     }
 
-    let mut written = 0;
-    // Write until we run out of characters or we are at the end of the buffer.
-    for (x, ch) in (start.x..sz.width).zip(s.chars()) {
-        written += 1;
-        buf.get_cell_mut(Position { x, ..start }).ch = ch;
+    let orig = pos.x;
+    for g in s.graphemes(true) {
+        let grapheme_width = (fc.display_width.str_width)(g);
+        let Some(added) = pos
+            .x
+            .checked_add(grapheme_width)
+            .filter(|added| sz.width >= *added)
+        else {
+            break;
+        };
+        fc.buffer.get_cell_mut(pos).set_str(g);
+        pos.x = added;
     }
 
-    written
+    pos.x - orig
 }
 
 #[cfg(test)]
@@ -31,8 +44,10 @@ mod tests {
     use crate::{
         buf_str,
         core::{
+            DisplayWidth,
             buffer::{flat::FlatBuffer, utils::dump_buffer_to_string as dbts},
             draw::Size,
+            timer::NoDelta,
         },
     };
 
@@ -40,31 +55,35 @@ mod tests {
         FlatBuffer::new(sz)
     }
 
+    fn make_fc(buf: &mut FlatBuffer) -> FrameContext<'_, FlatBuffer, NoDelta> {
+        FrameContext::new(NoDelta::new(), NoDelta::new(), buf, DisplayWidth::default())
+    }
+
     #[test]
     fn zero_area_buffer_returns_zero() {
         let mut buf = make_buf(Size::ZERO);
-        let written = draw_string(&mut buf, Position::ZERO, "hello");
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello");
         assert_eq!(written, 0);
     }
 
     #[test]
     fn zero_width_buffer_returns_zero() {
         let mut buf = make_buf(Size::new(0, 5));
-        let written = draw_string(&mut buf, Position::ZERO, "hello");
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello");
         assert_eq!(written, 0);
     }
 
     #[test]
     fn zero_height_buffer_returns_zero() {
         let mut buf = make_buf(Size::new(5, 0));
-        let written = draw_string(&mut buf, Position::ZERO, "hello");
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello");
         assert_eq!(written, 0);
     }
 
     #[test]
     fn start_x_out_of_bounds_returns_zero() {
         let mut buf = make_buf(Size::new(5, 3));
-        let written = draw_string(&mut buf, Position::new(5, 0), "hello");
+        let written = draw_string(make_fc(&mut buf), Position::new(5, 0), "hello");
         assert_eq!(written, 0);
 
         assert_eq!(dbts(&buf), buf_str!["     ", "     ", "     ",]);
@@ -73,7 +92,7 @@ mod tests {
     #[test]
     fn start_y_out_of_bounds_returns_zero() {
         let mut buf = make_buf(Size::new(5, 3));
-        let written = draw_string(&mut buf, Position::new(0, 3), "hello");
+        let written = draw_string(make_fc(&mut buf), Position::new(0, 3), "hello");
         assert_eq!(written, 0);
 
         assert_eq!(dbts(&buf), buf_str!["     ", "     ", "     ",]);
@@ -82,7 +101,7 @@ mod tests {
     #[test]
     fn empty_string_returns_zero() {
         let mut buf = make_buf(Size::new(5, 3));
-        let written = draw_string(&mut buf, Position::ZERO, "");
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "");
         assert_eq!(written, 0);
 
         assert_eq!(dbts(&buf), buf_str!["     ", "     ", "     ",]);
@@ -91,7 +110,7 @@ mod tests {
     #[test]
     fn string_fits_entirely() {
         let mut buf = make_buf(Size::new(10, 3));
-        let written = draw_string(&mut buf, Position::ZERO, "hello");
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello");
         assert_eq!(written, 5);
 
         assert_eq!(
@@ -103,7 +122,7 @@ mod tests {
     #[test]
     fn string_truncated_at_right_edge() {
         let mut buf = make_buf(Size::new(5, 3));
-        let written = draw_string(&mut buf, Position::ZERO, "hello world");
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello world");
         assert_eq!(written, 5);
 
         assert_eq!(dbts(&buf), buf_str!["hello", "     ", "     ",]);
@@ -112,7 +131,7 @@ mod tests {
     #[test]
     fn string_exactly_fills_width() {
         let mut buf = make_buf(Size::new(5, 2));
-        let written = draw_string(&mut buf, Position::ZERO, "abcde");
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "abcde");
         assert_eq!(written, 5);
 
         assert_eq!(dbts(&buf), buf_str!["abcde", "     ",]);
@@ -121,7 +140,7 @@ mod tests {
     #[test]
     fn start_at_nonzero_x() {
         let mut buf = make_buf(Size::new(10, 3));
-        let written = draw_string(&mut buf, Position::new(4, 0), "hello");
+        let written = draw_string(make_fc(&mut buf), Position::new(4, 0), "hello");
         assert_eq!(written, 5);
 
         assert_eq!(
@@ -133,7 +152,7 @@ mod tests {
     #[test]
     fn start_at_nonzero_y() {
         let mut buf = make_buf(Size::new(10, 3));
-        let written = draw_string(&mut buf, Position::new(0, 2), "hello");
+        let written = draw_string(make_fc(&mut buf), Position::new(0, 2), "hello");
         assert_eq!(written, 5);
 
         assert_eq!(
@@ -145,7 +164,7 @@ mod tests {
     #[test]
     fn start_at_nonzero_x_and_y() {
         let mut buf = make_buf(Size::new(10, 3));
-        let written = draw_string(&mut buf, Position::new(3, 1), "test");
+        let written = draw_string(make_fc(&mut buf), Position::new(3, 1), "test");
         assert_eq!(written, 4);
 
         assert_eq!(
@@ -157,7 +176,7 @@ mod tests {
     #[test]
     fn start_at_nonzero_x_truncated() {
         let mut buf = make_buf(Size::new(8, 2));
-        let written = draw_string(&mut buf, Position::new(5, 0), "hello");
+        let written = draw_string(make_fc(&mut buf), Position::new(5, 0), "hello");
         assert_eq!(written, 3);
 
         assert_eq!(dbts(&buf), buf_str!["     hel", "        ",]);
@@ -166,7 +185,7 @@ mod tests {
     #[test]
     fn single_cell_buffer() {
         let mut buf = make_buf(Size::new(1, 1));
-        let written = draw_string(&mut buf, Position::ZERO, "hello");
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "hello");
         assert_eq!(written, 1);
 
         assert_eq!(dbts(&buf), buf_str!["h"]);
@@ -175,9 +194,98 @@ mod tests {
     #[test]
     fn single_char_string() {
         let mut buf = make_buf(Size::new(5, 2));
-        let written = draw_string(&mut buf, Position::new(2, 0), "x");
+        let written = draw_string(make_fc(&mut buf), Position::new(2, 0), "x");
         assert_eq!(written, 1);
 
         assert_eq!(dbts(&buf), buf_str!["  x  ", "     ",]);
+    }
+
+    #[test]
+    fn emoji_takes_two_cells() {
+        let mut buf = make_buf(Size::new(5, 2));
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "😀");
+        assert_eq!(written, 2);
+
+        assert_eq!(dbts(&buf), buf_str!["😀  ", "     ",]);
+    }
+
+    #[test]
+    fn multiple_emoji() {
+        let mut buf = make_buf(Size::new(6, 2));
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "😀😎");
+        assert_eq!(written, 4);
+
+        assert_eq!(dbts(&buf), buf_str!["😀😎  ", "      ",]);
+    }
+
+    #[test]
+    fn emoji_truncated() {
+        let mut buf = make_buf(Size::new(3, 2));
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "😀");
+        assert_eq!(written, 2);
+
+        assert_eq!(dbts(&buf), buf_str!["😀 ", "   ",]);
+    }
+
+    #[test]
+    fn emoji_doesnt_fit_single_cell() {
+        let mut buf = make_buf(Size::new(1, 2));
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "😀");
+        assert_eq!(written, 0);
+
+        assert_eq!(dbts(&buf), buf_str![" ", " ",]);
+    }
+
+    #[test]
+    fn cjk_char_takes_two_cells() {
+        let mut buf = make_buf(Size::new(5, 2));
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "中");
+        assert_eq!(written, 2);
+
+        assert_eq!(dbts(&buf), buf_str!["中  ", "     ",]);
+    }
+
+    #[test]
+    fn cjk_mixed_with_ascii() {
+        let mut buf = make_buf(Size::new(10, 2));
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "中文abc");
+        assert_eq!(written, 7);
+
+        assert_eq!(dbts(&buf), buf_str!["中文abc   ", "          ",]);
+    }
+
+    #[test]
+    fn cjk_truncated() {
+        let mut buf = make_buf(Size::new(3, 2));
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "中文");
+        assert_eq!(written, 2);
+
+        assert_eq!(dbts(&buf), buf_str!["中 ", "   ",]);
+    }
+
+    #[test]
+    fn superscript_takes_one_cell() {
+        let mut buf = make_buf(Size::new(5, 2));
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "x²");
+        assert_eq!(written, 2);
+
+        assert_eq!(dbts(&buf), buf_str!["x²  ", "     ",]);
+    }
+
+    #[test]
+    fn mathematical_symbols() {
+        let mut buf = make_buf(Size::new(10, 2));
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "x²+y³=z⁴");
+        assert_eq!(written, 8);
+
+        assert_eq!(dbts(&buf), buf_str!["x²+y³=z⁴  ", "          ",]);
+    }
+
+    #[test]
+    fn mixed_unicode_content() {
+        let mut buf = make_buf(Size::new(15, 2));
+        let written = draw_string(make_fc(&mut buf), Position::ZERO, "Hi中😀文");
+
+        assert_eq!(dbts(&buf), buf_str!["Hi中😀文   ", "               ",]);
     }
 }

--- a/germterm/src/core/mod.rs
+++ b/germterm/src/core/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     },
 };
 
+#[derive(Clone, Debug)]
 pub struct DrawCall<'a> {
     pub pos: Position,
     pub cell: &'a Cell,

--- a/germterm/src/core/renderer/crossterm.rs
+++ b/germterm/src/core/renderer/crossterm.rs
@@ -71,8 +71,8 @@ impl<W: Write> Renderer for CrosstermRenderer<W> {
                 }
             }
             // Build the crossterm style from the cell's colors and attributes.
-            let fg = cell.style.fg().map(conv);
-            let bg = cell.style.bg().map(conv);
+            let fg = cell.style().fg().map(conv);
+            let bg = cell.style().bg().map(conv);
 
             let ct_attrs = [
                 (Attributes::BOLD, style::Attribute::Bold),
@@ -82,7 +82,7 @@ impl<W: Write> Renderer for CrosstermRenderer<W> {
             ]
             .iter()
             .fold(style::Attributes::none(), |acc, &(flag, attr)| {
-                if cell.style.attributes().contains(flag) {
+                if cell.style().attributes().contains(flag) {
                     acc | attr
                 } else {
                     acc
@@ -113,7 +113,7 @@ impl<W: Write> Renderer for CrosstermRenderer<W> {
                 last_style = Some(cell_style);
             }
 
-            queue!(&mut self.out, style::Print(cell.ch))?;
+            queue!(&mut self.out, style::Print(cell.as_str()))?;
 
             last_pos = Some((pos.x, pos.y));
         }

--- a/germterm/src/core/widget/block/mod.rs
+++ b/germterm/src/core/widget/block/mod.rs
@@ -176,24 +176,15 @@ impl<'a, D: TimerDelta, B: BlockSet, T: Widget<D> + LineWidth> Widget<D> for Blo
             && size.width > 0
         {
             let cur = ctx.buffer_mut().get_cell_mut(Position::ZERO);
-            cur.ch = self
-                .set
-                .top_left(&cur.ch.to_string())
-                .chars()
-                .next()
-                .unwrap_or_default();
+            cur.set_str(self.set.top_left(cur.as_str()));
         }
 
         // top side
         if self.sides.contains(BorderSides::TOP) && size.width > horizontal_offset {
             for x in left_offset..x_end {
                 let cur = ctx.buffer_mut().get_cell_mut(Position { x, y: 0 });
-                cur.ch = self
-                    .set
-                    .top(&cur.ch.to_string())
-                    .chars()
-                    .next()
-                    .unwrap_or_default();
+
+                cur.set_str(self.set.top(cur.as_str()));
             }
 
             // Draw the top titles
@@ -214,12 +205,7 @@ impl<'a, D: TimerDelta, B: BlockSet, T: Widget<D> + LineWidth> Widget<D> for Blo
                 x: size.width.saturating_sub(1),
                 y: 0,
             });
-            cur.ch = self
-                .set
-                .top_right(&cur.ch.to_string())
-                .chars()
-                .next()
-                .unwrap_or_default();
+            cur.set_str(self.set.top_right(cur.as_str()));
         }
 
         // LR sides
@@ -229,12 +215,8 @@ impl<'a, D: TimerDelta, B: BlockSet, T: Widget<D> + LineWidth> Widget<D> for Blo
             if self.sides.contains(BorderSides::LEFT) {
                 for y in top_offset..h_end {
                     let cur = ctx.buffer_mut().get_cell_mut(Position::new(0, y));
-                    cur.ch = self
-                        .set
-                        .left(&cur.ch.to_string())
-                        .chars()
-                        .next()
-                        .unwrap_or_default();
+
+                    cur.set_str(self.set.left(cur.as_str()));
                 }
             }
 
@@ -245,12 +227,8 @@ impl<'a, D: TimerDelta, B: BlockSet, T: Widget<D> + LineWidth> Widget<D> for Blo
                         x: size.width.saturating_sub(right_offset),
                         y,
                     });
-                    cur.ch = self
-                        .set
-                        .right(&cur.ch.to_string())
-                        .chars()
-                        .next()
-                        .unwrap_or_default();
+
+                    cur.set_str(self.set.right(cur.as_str()));
                 }
             }
         }
@@ -260,12 +238,8 @@ impl<'a, D: TimerDelta, B: BlockSet, T: Widget<D> + LineWidth> Widget<D> for Blo
             let cur = ctx
                 .buffer_mut()
                 .get_cell_mut(Position::new(0, size.height.saturating_sub(1)));
-            cur.ch = self
-                .set
-                .bottom_left(&cur.ch.to_string())
-                .chars()
-                .next()
-                .unwrap_or_default();
+
+            cur.set_str(self.set.bottom_left(cur.as_str()));
         }
 
         // bottom
@@ -273,12 +247,8 @@ impl<'a, D: TimerDelta, B: BlockSet, T: Widget<D> + LineWidth> Widget<D> for Blo
             let y = size.height.saturating_sub(1);
             for x in left_offset..x_end {
                 let cur = ctx.buffer_mut().get_cell_mut(Position { x, y });
-                cur.ch = self
-                    .set
-                    .bottom(&cur.ch.to_string())
-                    .chars()
-                    .next()
-                    .unwrap_or_default();
+
+                cur.set_str(self.set.bottom(cur.as_str()));
             }
 
             let bottom_titles = self
@@ -296,12 +266,8 @@ impl<'a, D: TimerDelta, B: BlockSet, T: Widget<D> + LineWidth> Widget<D> for Blo
                 x: size.width.saturating_sub(1),
                 y: size.height.saturating_sub(1),
             });
-            cur.ch = self
-                .set
-                .bottom_right(&cur.ch.to_string())
-                .chars()
-                .next()
-                .unwrap_or_default();
+
+            cur.set_str(self.set.bottom_right(cur.as_str()));
         }
     }
 }

--- a/germterm/src/core/widget/block/mod.rs
+++ b/germterm/src/core/widget/block/mod.rs
@@ -276,10 +276,10 @@ impl<'a, D: TimerDelta, B: BlockSet, T: Widget<D> + LineWidth> Widget<D> for Blo
 mod tests {
     use super::*;
     use crate::{
-        buf_str,
+        buf_assert_eq, buffer,
         core::{
             DisplayWidth,
-            buffer::{paired::PairedBuffer, utils::dump_buffer_to_string as dbts},
+            buffer::paired::PairedBuffer,
             draw::Size,
             timer::NoDelta,
             widget::block::{
@@ -310,9 +310,15 @@ mod tests {
     fn all_sides() {
         let buf = draw_block(Block::new(SimpleBorderSet::ASCII), Size::new(5, 5));
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["+---+", "|   |", "|   |", "|   |", "+---+",]
+        buf_assert_eq!(
+            buf,
+            buffer![
+                ["+", "-", "-", "-", "+"],
+                ["|", empty(3), "|"],
+                ["|", empty(3), "|"],
+                ["|", empty(3), "|"],
+                ["+", "-", "-", "-", "+"],
+            ]
         );
     }
 
@@ -323,9 +329,15 @@ mod tests {
             Size::new(5, 5),
         );
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["-----", "     ", "     ", "     ", "     ",]
+        buf_assert_eq!(
+            buf,
+            buffer![
+                ["-", "-", "-", "-", "-"],
+                [empty(5)],
+                [empty(5)],
+                [empty(5)],
+                [empty(5)],
+            ]
         );
     }
 
@@ -336,9 +348,15 @@ mod tests {
             Size::new(5, 5),
         );
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["     ", "     ", "     ", "     ", "-----",]
+        buf_assert_eq!(
+            buf,
+            buffer![
+                [empty(5)],
+                [empty(5)],
+                [empty(5)],
+                [empty(5)],
+                ["-", "-", "-", "-", "-"],
+            ]
         );
     }
 
@@ -349,9 +367,15 @@ mod tests {
             Size::new(5, 5),
         );
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["|    ", "|    ", "|    ", "|    ", "|    ",]
+        buf_assert_eq!(
+            buf,
+            buffer![
+                ["|", empty(4)],
+                ["|", empty(4)],
+                ["|", empty(4)],
+                ["|", empty(4)],
+                ["|", empty(4)],
+            ]
         );
     }
 
@@ -362,9 +386,15 @@ mod tests {
             Size::new(5, 5),
         );
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["    |", "    |", "    |", "    |", "    |",]
+        buf_assert_eq!(
+            buf,
+            buffer![
+                [empty(4), "|"],
+                [empty(4), "|"],
+                [empty(4), "|"],
+                [empty(4), "|"],
+                [empty(4), "|"],
+            ]
         );
     }
 
@@ -375,9 +405,15 @@ mod tests {
             Size::new(5, 5),
         );
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["+----", "|    ", "|    ", "|    ", "|    ",]
+        buf_assert_eq!(
+            buf,
+            buffer![
+                ["+", "-", "-", "-", "-"],
+                ["|", empty(4)],
+                ["|", empty(4)],
+                ["|", empty(4)],
+                ["|", empty(4)],
+            ]
         );
     }
 
@@ -388,9 +424,15 @@ mod tests {
             Size::new(5, 5),
         );
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["-----", "     ", "     ", "     ", "-----",]
+        buf_assert_eq!(
+            buf,
+            buffer![
+                ["-", "-", "-", "-", "-"],
+                [empty(5)],
+                [empty(5)],
+                [empty(5)],
+                ["-", "-", "-", "-", "-"],
+            ]
         );
     }
 
@@ -401,9 +443,15 @@ mod tests {
             Size::new(5, 5),
         );
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["|   |", "|   |", "|   |", "|   |", "|   |",]
+        buf_assert_eq!(
+            buf,
+            buffer![
+                ["|", empty(3), "|"],
+                ["|", empty(3), "|"],
+                ["|", empty(3), "|"],
+                ["|", empty(3), "|"],
+                ["|", empty(3), "|"],
+            ]
         );
     }
 
@@ -414,9 +462,9 @@ mod tests {
             Size::new(5, 5),
         );
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["     ", "     ", "     ", "     ", "     ",]
+        buf_assert_eq!(
+            buf,
+            buffer![[empty(5)], [empty(5)], [empty(5)], [empty(5)], [empty(5)],]
         );
     }
 
@@ -431,9 +479,13 @@ mod tests {
             Size::new(10, 3),
         );
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["+Hi------+", "|        |", "+--------+",]
+        buf_assert_eq!(
+            buf,
+            buffer![
+                ["+", "H", "i", "-", "-", "-", "-", "-", "-", "+"],
+                ["|", empty(8), "|"],
+                ["+", "-", "-", "-", "-", "-", "-", "-", "-", "+"],
+            ]
         );
     }
 
@@ -447,9 +499,13 @@ mod tests {
             Size::new(10, 3),
         );
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["+---Hi---+", "|        |", "+--------+",]
+        buf_assert_eq!(
+            buf,
+            buffer![
+                ["+", "-", "-", "-", "H", "i", "-", "-", "-", "+"],
+                ["|", empty(8), "|"],
+                ["+", "-", "-", "-", "-", "-", "-", "-", "-", "+"],
+            ]
         );
     }
 
@@ -462,9 +518,13 @@ mod tests {
             Size::new(10, 3),
         );
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["+------Hi+", "|        |", "+--------+",]
+        buf_assert_eq!(
+            buf,
+            buffer![
+                ["+", "-", "-", "-", "-", "-", "-", "H", "i", "+"],
+                ["|", empty(8), "|"],
+                ["+", "-", "-", "-", "-", "-", "-", "-", "-", "+"],
+            ]
         );
     }
 
@@ -477,9 +537,13 @@ mod tests {
             Size::new(10, 3),
         );
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["+--------+", "|        |", "+Hi------+",]
+        buf_assert_eq!(
+            buf,
+            buffer![
+                ["+", "-", "-", "-", "-", "-", "-", "-", "-", "+"],
+                ["|", empty(8), "|"],
+                ["+", "H", "i", "-", "-", "-", "-", "-", "-", "+"],
+            ]
         );
     }
 
@@ -496,9 +560,13 @@ mod tests {
             Size::new(10, 3),
         );
 
-        assert_eq!(
-            dbts(&buf),
-            buf_str!["+top-----+", "|        |", "+bot-----+",]
+        buf_assert_eq!(
+            buf,
+            buffer![
+                ["+", "t", "o", "p", "-", "-", "-", "-", "-", "+"],
+                ["|", empty(8), "|"],
+                ["+", "b", "o", "t", "-", "-", "-", "-", "-", "+"],
+            ]
         );
     }
 }

--- a/germterm/src/core/widget/text/line.rs
+++ b/germterm/src/core/widget/text/line.rs
@@ -92,7 +92,7 @@ where
         // Set the style for the cells that are untouched in our `Line`
         for x in offset..sz.width {
             buf.get_cell_mut(Position::new(x, 0))
-                .style
+                .style_mut()
                 .merge(self.style);
         }
     }

--- a/germterm/src/core/widget/text/line.rs
+++ b/germterm/src/core/widget/text/line.rs
@@ -4,7 +4,7 @@ use crate::{
     core::{
         DisplayWidth,
         buffer::slice::SubBuffer,
-        draw::{Position, Rect, Size},
+        draw::{Position, Rect, gfx::text::WrittenTracker},
         widget::{
             FrameContext, SimpleWidget,
             text::{LineWidth, span::Span},
@@ -55,15 +55,60 @@ where
             __p: PhantomData,
         }
     }
+
+    pub fn fill_cells(
+        &self,
+        ctx: FrameContext<'_, impl crate::core::buffer::Buffer>,
+    ) -> WrittenTracker {
+        let sz = ctx.buffer.size();
+
+        if sz.area() == 0 {
+            return WrittenTracker::default();
+        }
+
+        let mut wt = WrittenTracker::default();
+        for span in self.spans.as_ref().iter() {
+            // Cannot underflow as its checked at the end of the iteration and we break if it does
+            let allowed_width = sz.width - wt.cells;
+
+            let swt = span
+                .as_borrowed()
+                .with_style(self.style.merged(span.style()))
+                .fill_cells(
+                    FrameContext::new(
+                        ctx.total_time,
+                        ctx.delta,
+                        &mut SubBuffer::new(ctx.buffer, Rect::new(Position::new(wt.cells, 0), sz)),
+                        ctx.display_width,
+                    ),
+                    allowed_width,
+                );
+            wt.cells += swt.cells;
+            wt.bytes += swt.bytes;
+
+            if wt.cells >= sz.width {
+                break;
+            }
+        }
+
+        // Set the style for the cells that are untouched in our `Line`
+        for x in wt.cells..sz.width {
+            ctx.buffer
+                .get_cell_mut(Position::new(x, 0))
+                .style_mut()
+                .merge(self.style);
+        }
+
+        wt
+    }
 }
 
 impl<'a, Spans> SimpleWidget for Line<'a, Spans>
 where
     Spans: AsRef<[Span<'a>]>,
 {
-    fn draw(&self, mut ctx: FrameContext<'_, impl crate::core::buffer::Buffer>) {
-        let buf = ctx.buffer_mut();
-        let sz = buf.size();
+    fn draw(&self, ctx: FrameContext<'_, impl crate::core::buffer::Buffer>) {
+        let sz = ctx.buffer.size();
 
         if sz.area() == 0 {
             return;
@@ -77,12 +122,15 @@ where
                 .as_borrowed()
                 .with_style(self.style.merged(span.style()))
                 .fill_cells(
-                    &mut SubBuffer::new(
-                        buf,
-                        Rect::new(Position::new(offset, 0), Size::new(allowed_width, 1)),
+                    FrameContext::new(
+                        ctx.total_time,
+                        ctx.delta,
+                        &mut SubBuffer::new(ctx.buffer, Rect::new(Position::new(offset, 0), sz)),
+                        ctx.display_width,
                     ),
                     allowed_width,
                 )
+                .cells
                 .saturating_add(offset);
             if offset >= sz.width {
                 break;
@@ -91,7 +139,8 @@ where
 
         // Set the style for the cells that are untouched in our `Line`
         for x in offset..sz.width {
-            buf.get_cell_mut(Position::new(x, 0))
+            ctx.buffer
+                .get_cell_mut(Position::new(x, 0))
                 .style_mut()
                 .merge(self.style);
         }

--- a/germterm/src/core/widget/text/span.rs
+++ b/germterm/src/core/widget/text/span.rs
@@ -128,18 +128,7 @@ impl<'a> Span<'a> {
         let mut written = 0;
         for y in 0..sz.height {
             for x in 0..sz.width {
-                let c = buf.get_cell_mut(Position::new(x, y));
-                written = sz.width as u32 * y as u32 + x as u32;
-                // TODO: add cell merging once cell styling is stored
-                if let Some(ch) = chars.next() {
-                    c.style.merge(self.style);
-                    c.ch = ch;
-                    if written >= limit {
-                        break;
-                    }
-                } else {
-                    break;
-                }
+                todo!()
             }
         }
 

--- a/germterm/src/core/widget/text/span.rs
+++ b/germterm/src/core/widget/text/span.rs
@@ -3,8 +3,13 @@ use std::borrow::Cow;
 use crate::{
     core::{
         DisplayWidth,
-        buffer::Buffer,
-        draw::Position,
+        draw::{
+            Position, Rect,
+            gfx::{
+                normal::draw_style,
+                text::{WrittenTracker, draw_text},
+            },
+        },
         timer::NoDelta,
         widget::{FrameContext, SimpleWidget, text::LineWidth},
     },
@@ -116,23 +121,16 @@ impl<'a> Span<'a> {
         &self.content
     }
 
-    /// Fills the cells in the provided buffer as much as possible without exceeding `limit` cells.
+    /// Fills the cells in the for row of the provided buffer as much as possible without exceeding `limit` cells.
     ///
     /// This is mainly intended to be called from other [`Widget`]'s where they would account for
     /// line wrapping themselves. In other words this is a primitive text drawer in widget form.
-    pub fn fill_cells<Buf: Buffer>(&self, buf: &mut Buf, limit: u16) -> u16 {
-        // TODO: use proper cell length checks here (should get passed a `&DisplayWidth` as arg)
-        let limit = limit as u32;
-        let sz = buf.size();
-        let mut chars = self.content.chars();
-        let mut written = 0;
-        for y in 0..sz.height {
-            for x in 0..sz.width {
-                todo!()
-            }
-        }
-
-        written as u16
+    pub fn fill_cells(
+        &self,
+        ctx: FrameContext<'_, impl crate::core::buffer::Buffer, NoDelta>,
+        limit: u16,
+    ) -> WrittenTracker {
+        draw_text(ctx, Position::ZERO, &self.content, self.style, limit)
     }
 
     /// Returns a borrowed copy of this span that references the same underlying string.
@@ -145,8 +143,22 @@ impl<'a> Span<'a> {
 }
 
 impl<'a> SimpleWidget for Span<'a> {
-    fn draw(&self, ctx: FrameContext<'_, impl crate::core::buffer::Buffer, NoDelta>) {
-        self.fill_cells(ctx.buffer, ctx.buffer.size().width);
+    fn draw(&self, mut ctx: FrameContext<'_, impl crate::core::buffer::Buffer, NoDelta>) {
+        let sz = ctx.buffer().size();
+        let wt = self.fill_cells(
+            FrameContext {
+                total_time: ctx.total_time,
+                delta: ctx.delta,
+                buffer: ctx.buffer,
+                display_width: ctx.display_width,
+            },
+            sz.width,
+        );
+        draw_style(
+            ctx.buffer_mut(),
+            Rect::new(Position::new(wt.cells, 0), sz),
+            self.style,
+        );
     }
 }
 


### PR DESCRIPTION
Currently the library doesn't handle emoji and some symbols correctly. This is because the current implementation uses a `char` which isn't always able to store what a human considers a character.

# Memory Usage

As solution we are required to store a string type such as `String`, `Box<str>`, `CompactString` or `SmolStr`. 
However each of these have the same problem. They double the size of a `Cell` which increases memory usage as with padding a `Cell` would occupy 64 bytes (on a 64 bit system).

(technically `Box<str>` doesnt increase the size of `Cell` to 64 bytes but once we support underline colors `Cell` will get padded out to 64 bytes even with `Box<str>` so using it is only a temporary solution)

This is mostly fine on desktop systems but on embedded devices memory is limited. To avoid issues on such platforms I have implemented a data structure similar to `Swift`'s and `compact_str`'s small string optimizations but has one key difference - a single `SinStr` takes up the same space as a single pointer. Lowering the size of a `Cell` to 32 bytes (which is the current size of a `Cell`).

For details related to how `sinstr` works the repo can be found at: https://github.com/airblast-dev/sinstr

# Rendering Logic

TODO: mention changes to draw primitives once they are refactored.